### PR TITLE
Update to rayon 0.8.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["csheratt"]
 atom = "0.3"
 
 [dependencies.rayon]
-version = "0.7.1"
+version = "0.8.2"
 optional = true
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hibitset"
-version = "0.1.3"
+version = "0.2.0"
 description = "Hierarchical bit set structure"
 documentation = "https://slide-rs.github.io/hibitset/"
 repository = "https://github.com/slide-rs/hibitset"


### PR DESCRIPTION
This is required to close https://github.com/slide-rs/specs/issues/236.