### PR TITLE
Add IntoIterator for our BitSetLikes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hibitset"
-version = "0.3.1"
+version = "0.3.2"
 description = "Hierarchical bit set structure"
 documentation = "https://slide-rs.github.io/hibitset/"
 repository = "https://github.com/slide-rs/hibitset"

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,7 +1,7 @@
 
 use std::ops::{BitAnd, BitOr, BitXor, Not};
 
-use {BitSet, BitSetLike};
+use {BitIter, BitSet, BitSetLike};
 
 /// `BitSetAnd` takes two [`BitSetLike`] items, and merges the masks
 /// returning a new virtual set, which represents an intersection of the
@@ -116,6 +116,16 @@ impl<A: BitSetLike, B: BitSetLike> BitSetLike for BitSetXor<A, B> {
 
 macro_rules! operator {
     ( impl < ( $( $lifetime:tt )* ) ( $( $arg:ident ),* ) > for $bitset:ty ) => {
+        impl<$( $lifetime, )* $( $arg ),*> IntoIterator for $bitset
+            where $( $arg: BitSetLike ),*
+        {
+            type Item = <BitIter<Self> as Iterator>::Item;
+            type IntoIter = BitIter<Self>;
+            fn into_iter(self) -> Self::IntoIter {
+                self.iter()
+            }
+        }
+
         impl<$( $lifetime, )* $( $arg ),*> Not for $bitset
             where $( $arg: BitSetLike ),*
         {


### PR DESCRIPTION
Makes it so `.iter()` is implicitly called when using the BitSetLikes in `for` iterator.

Also bumps the version up to 0.3.2