### PR TITLE
Improve parallel iterators splitting behaviour

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ script:
   - cargo test --verbose
   - cargo build --verbose --no-default-features
   - cargo test --verbose --no-default-features
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then (cargo bench --verbose); fi
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then (cargo bench --verbose --no-default-features); fi
 env:
   - RUST_BACKTRACE=1

--- a/benches/iter.rs
+++ b/benches/iter.rs
@@ -1,0 +1,223 @@
+#![feature(test)]
+extern crate hibitset;
+extern crate test;
+extern crate rand;
+extern crate rayon;
+
+use hibitset::{BitSet, BitSetLike};
+
+use test::{Bencher, black_box};
+
+use rand::{Rng, XorShiftRng};
+
+use rayon::iter::ParallelIterator;
+
+use self::Mode::*;
+
+enum Mode {
+    Seq,
+    Par(u8),
+}
+
+fn bench(n: usize, mode: Mode, b: &mut Bencher) {
+    let mut rng = XorShiftRng::new_unseeded();
+    let mut bitset = BitSet::with_capacity(1048576);
+    for _ in 0..n {
+        let index = rng.gen_range(0, 1048576);
+        bitset.add(index);
+    }
+    match mode {
+        Seq => b.iter(|| black_box((&bitset).iter().map(black_box).count())),
+        Par(splits) => b.iter(|| black_box((&bitset).par_iter().layers_split(splits).map(black_box).count()))
+    }
+}
+
+#[bench]
+fn iter_100(b: &mut Bencher) {
+    bench(100, Seq, b);
+}
+
+#[bench]
+fn iter_1000(b: &mut Bencher) {
+    bench(1000, Seq, b);
+}
+
+#[bench]
+fn iter_10000(b: &mut Bencher) {
+    bench(10000, Seq, b);
+}
+
+#[bench]
+fn iter_100000(b: &mut Bencher) {
+    bench(100000, Seq, b);
+}
+
+#[bench]
+fn iter_1000000(b: &mut Bencher) {
+    bench(1000000, Seq, b);
+}
+
+#[bench]
+fn par_iter_3_100(b: &mut Bencher) {
+    bench(100, Par(3), b);
+}
+
+#[bench]
+fn par_iter_3_1000(b: &mut Bencher) {
+    bench(1000, Par(3), b);
+}
+
+#[bench]
+fn par_iter_3_10000(b: &mut Bencher) {
+    bench(10000, Par(3), b);
+}
+
+#[bench]
+fn par_iter_3_100000(b: &mut Bencher) {
+    bench(100000, Par(3), b);
+}
+
+#[bench]
+fn par_iter_3_1000000(b: &mut Bencher) {
+    bench(1000000, Par(3), b);
+}
+
+#[bench]
+fn par_iter_2_100(b: &mut Bencher) {
+    bench(100, Par(2), b);
+}
+
+#[bench]
+fn par_iter_2_1000(b: &mut Bencher) {
+    bench(1000, Par(2), b);
+}
+
+#[bench]
+fn par_iter_2_10000(b: &mut Bencher) {
+    bench(10000, Par(2), b);
+}
+
+#[bench]
+fn par_iter_2_100000(b: &mut Bencher) {
+    bench(100000, Par(2), b);
+}
+
+#[bench]
+fn par_iter_2_1000000(b: &mut Bencher) {
+    bench(1000000, Par(2), b);
+}
+
+fn bench_payload(n: usize, splits: u8, payload: u32, b: &mut Bencher) {
+    let mut rng = XorShiftRng::new_unseeded();
+    let mut bitset = BitSet::with_capacity(1048576);
+    for _ in 0..n {
+        let index = rng.gen_range(0, 1048576);
+        bitset.add(index);
+    }
+    b.iter(|| black_box((&bitset).par_iter().layers_split(splits).map(|mut n| {
+        for i in 0..payload {
+            n += black_box(i);
+        }
+        black_box(n)
+    }).count()));
+}
+
+#[bench]
+fn par_3_payload_1000_iter_100(b: &mut Bencher) {
+    bench_payload(100, 3, 1000, b);
+}
+
+#[bench]
+fn par_3_payload_1000_iter_1000(b: &mut Bencher) {
+    bench_payload(1000, 3, 1000, b);
+}
+
+#[bench]
+fn par_3_payload_1000_iter_10000(b: &mut Bencher) {
+    bench_payload(10000, 3, 1000, b);
+}
+
+#[bench]
+fn par_3_payload_1000_iter_100000(b: &mut Bencher) {
+    bench_payload(100000, 3, 1000, b);
+}
+
+#[bench]
+fn par_3_payload_1000_iter_1000000(b: &mut Bencher) {
+    bench_payload(1000000, 3, 1000, b);
+}
+
+#[bench]
+fn par_2_payload_1000_iter_100(b: &mut Bencher) {
+    bench_payload(100, 2, 1000, b);
+}
+
+#[bench]
+fn par_2_payload_1000_iter_1000(b: &mut Bencher) {
+    bench_payload(1000, 2, 1000, b);
+}
+
+#[bench]
+fn par_2_payload_1000_iter_10000(b: &mut Bencher) {
+    bench_payload(10000, 2, 1000, b);
+}
+
+#[bench]
+fn par_2_payload_1000_iter_100000(b: &mut Bencher) {
+    bench_payload(100000, 2, 1000, b);
+}
+
+#[bench]
+fn par_2_payload_1000_iter_1000000(b: &mut Bencher) {
+    bench_payload(1000000, 2, 1000, b);
+}
+
+#[bench]
+fn par_3_payload_100_iter_100(b: &mut Bencher) {
+    bench_payload(100, 3, 100, b);
+}
+
+#[bench]
+fn par_3_payload_100_iter_1000(b: &mut Bencher) {
+    bench_payload(1000, 3, 100, b);
+}
+
+#[bench]
+fn par_3_payload_100_iter_10000(b: &mut Bencher) {
+    bench_payload(10000, 3, 100, b);
+}
+
+#[bench]
+fn par_3_payload_100_iter_100000(b: &mut Bencher) {
+    bench_payload(100000, 3, 100, b);
+}
+
+#[bench]
+fn par_3_payload_100_iter_1000000(b: &mut Bencher) {
+    bench_payload(1000000, 3, 100, b);
+}
+
+#[bench]
+fn par_2_payload_100_iter_100(b: &mut Bencher) {
+    bench_payload(100, 2, 100, b);
+}
+
+#[bench]
+fn par_2_payload_100_iter_1000(b: &mut Bencher) {
+    bench_payload(1000, 2, 100, b);
+}
+
+#[bench]
+fn par_2_payload_100_iter_10000(b: &mut Bencher) {
+    bench_payload(10000, 2, 100, b);
+}
+
+#[bench]
+fn par_2_payload_100_iter_100000(b: &mut Bencher) {
+    bench_payload(100000, 2, 100, b);
+}
+
+#[bench]
+fn par_2_payload_100_iter_1000000(b: &mut Bencher) {
+    bench_payload(1000000, 2, 100, b);
+}

--- a/src/iter/parallel.rs
+++ b/src/iter/parallel.rs
@@ -1,9 +1,8 @@
-use std::mem::size_of;
-
 use rayon::iter::ParallelIterator;
 use rayon::iter::internal::{UnindexedProducer, UnindexedConsumer, Folder, bridge_unindexed};
 
 use iter::{BITS, BitSetLike, BitIter, Index};
+use util::average_bit;
 
 /// A `ParallelIterator` over a [`BitSetLike`] structure.
 ///
@@ -44,6 +43,12 @@ impl<'a, T: 'a + Send + Sync> UnindexedProducer for BitProducer<'a, T>
     where T: BitSetLike
 {
     type Item = Index;
+    /// The splitting strategy used assumes that the bitset is distributed
+    /// axproximately uniformly.
+    ///
+    /// Splitting the bitset into two parts is done highest level
+    /// that still has more than one children.
+    /// TODO: Better explanation of the algorithm.
     fn split(mut self) -> (Self, Option<Self>) {
         let other = {
             let mut handle_level = |level: usize| {
@@ -51,49 +56,46 @@ impl<'a, T: 'a + Send + Sync> UnindexedProducer for BitProducer<'a, T>
                 if self.0.masks[level] == 0 {
                     return None;
                 }
-                // Find first bit that is set
-                let first_bit = self.0.masks[level].trailing_zeros();
-                // Find last bit that is set
-                let usize_bits = size_of::<usize>() * 8;
-                let last_bit = usize_bits as u32 - self.0.masks[level].leading_zeros() - 1;
+                let average_bit = average_bit(self.0.masks[level]);
+
                 // If this is the highest level, there is no prefix saved as it's always zero
                 let level_prefix = self.0.prefix.get(level).cloned().unwrap_or(0);
                 // If there is one bit left, descend
-                if first_bit == last_bit {
+                let first_bit = self.0.masks[level].trailing_zeros();
+
+                if let Some(average_bit) = average_bit {
+                    let mask = (1 << (average_bit - 1)) - 1;
+
+                    let mut other = BitProducer(BitIter::new(self.0.set, [0, 0, 0, 0], [0, 0, 0]));
+                    let original_mask = self.0.masks[level];
+                    // Take the higher half of the mask
+                    other.0.masks[level] = original_mask & !mask;
+                    // The higher levels of masks don't need to preserved as they are empty.
+                    for n in &self.0.masks[(level + 1)..] {
+                        debug_assert_eq!(*n, 0);
+                    }
+                    // The higher half starts iterating after the average
+                    other.0.prefix[level - 1] = (level_prefix | average_bit as u32) << BITS;
+                    // And preserve the prefix of the higher levels
+                    other.0.prefix[level..].copy_from_slice(&self.0.prefix[level..]);
+                    // Take the lower half the mask
+                    self.0.masks[level] = original_mask & mask;
+                    // Combined mask of the current level should now equal the original mask
+                    debug_assert_eq!(self.0.masks[level] | other.0.masks[level], original_mask);
+                    // The lower half starts iterating from the first bit
+                    self.0.prefix[level - 1] = (level_prefix | first_bit) << BITS;
+                    Some(other)
+                } else {
                     // Calculate the index based on prefix and the bit that is descended to
-                    let idx = (level_prefix | first_bit) as usize;
+                    let idx = level_prefix as usize | first_bit as usize;
                     // When descending all of the iteration happens in the child of the bit that is left
                     self.0.prefix[level - 1] = (idx as u32) << BITS;
                     // And because all the iteration happens in the child, it's parent can be removed.
                     self.0.masks[level] = 0;
                     // Get the mask of the child layer from the set
                     self.0.masks[level - 1] = get_from_layer(self.0.set, level - 1, idx);
-                    return None;
+                    None
                 }
-                // Make the split point to be the average of first and last bit.
-                let after_average = (first_bit + last_bit) / 2 + 1;
-                // A bit mask to get the lower half of the mask
-                // This cuts the mask to half from the average
-                let mask = (1 << after_average) - 1;
-                let mut other = BitProducer(BitIter::new(self.0.set, [0, 0, 0, 0], [0, 0, 0]));
-                let original_mask = self.0.masks[level];
-                // Take the higher half of the mask
-                other.0.masks[level] = original_mask & !mask;
-                // The higher levels of masks don't need to preserved as they are empty.
-                for n in &self.0.masks[(level + 1)..] {
-                    debug_assert_eq!(*n, 0);
-                }
-                // The higher half starts iterating after the average
-                other.0.prefix[level - 1] = (level_prefix | after_average) << BITS;
-                // And preserve the prefix of the higher levels
-                other.0.prefix[level..].copy_from_slice(&self.0.prefix[level..]);
-                // Take the lower half the mask
-                self.0.masks[level] = original_mask & mask;
-                // Combined mask of the current level should now equal the original mask
-                debug_assert_eq!(self.0.masks[level] | other.0.masks[level], original_mask);
-                // The lower half starts iterating from the first bit
-                self.0.prefix[level - 1] = (level_prefix | first_bit) << BITS;
-                Some(other)
             };
             handle_level(3)
                 .or_else(|| handle_level(2))
@@ -107,6 +109,44 @@ impl<'a, T: 'a + Send + Sync> UnindexedProducer for BitProducer<'a, T>
     {
         folder.consume_iter(self.0)
     }
+}
+
+#[test]
+fn max_splitting_of_two_top_bits() {
+    fn visit<T>(mut us: BitProducer<T>, d: usize, i: usize, mut trail: String, c: &mut usize)
+        where T: Send +
+                 Sync +
+                 BitSetLike
+    {
+        if d == 0 {
+            assert!(us.split().1.is_none());
+            *c += 1;
+        } else {
+            for j in 1..(i + 1) {
+                let (new_us, them) = us.split();
+                us = new_us;
+                let them = them.expect(&trail);
+                let mut trail = trail.clone();
+                trail.push_str(&i.to_string());
+                visit(them, d, i - j, trail, c);
+            }
+            trail.push_str("u");
+            visit(us, d - 1, 6, trail, c);
+        }
+    }
+
+    let mut c = ::BitSet::new();
+    for i in 0..524288 {
+        assert!(!c.add(i));
+    }
+
+    let us = BitProducer((&c).iter());
+    let (us, them) = us.split();
+
+    let mut count = 0;
+    visit(us, 2, 6, "u".to_owned(), &mut count);
+    visit(them.expect("Splitting top level"), 2, 6, "t".to_owned(), &mut count);
+    assert_eq!(524288 / 64, count);
 }
 
 /// Gets usize by layer and index from bit set.

--- a/src/iter/parallel.rs
+++ b/src/iter/parallel.rs
@@ -8,15 +8,42 @@ use util::average_ones;
 ///
 /// [`BitSetLike`]: ../../trait.BitSetLike.html
 #[derive(Debug)]
-pub struct BitParIter<T>(T);
+pub struct BitParIter<T>(T, u8);
 
 impl<T> BitParIter<T> {
     /// Creates a new `BitParIter`. You usually don't call this function
     /// but just [`.par_iter()`] on a bit set.
     ///
+    /// Default layer split amount is 3.
+    ///
     /// [`.par_iter()`]: ../../trait.BitSetLike.html#method.par_iter
     pub fn new(set: T) -> Self {
-        BitParIter(set)
+        BitParIter(set, 3)
+    }
+
+    /// Sets how many layers are split when forking.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate rayon;
+    /// # extern crate hibitset;
+    /// # use hibitset::{BitSet, BitSetLike};
+    /// # use rayon::iter::ParallelIterator;
+    /// # fn main() {
+    /// let mut bitset = BitSet::new();
+    /// bitset.par_iter()
+    ///     .layers_split(2)
+    ///     .count();
+    /// # }
+    /// ```
+    ///
+    /// The value should be in range [1, 3]
+    pub fn layers_split(mut self, layers: u8) -> Self {
+        assert!(layers >= 1);
+        assert!(layers <= 3);
+        self.1 = layers;
+        self
     }
 }
 
@@ -28,7 +55,7 @@ impl<T> ParallelIterator for BitParIter<T>
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
         where C: UnindexedConsumer<Self::Item>
     {
-        bridge_unindexed(BitProducer((&self.0).iter()), consumer)
+        bridge_unindexed(BitProducer((&self.0).iter(), self.1), consumer)
     }
 }
 
@@ -37,7 +64,7 @@ impl<T> ParallelIterator for BitParIter<T>
 ///
 /// Usually used internally by `BitParIter`.
 #[derive(Debug)]
-pub struct BitProducer<'a, T: 'a + Send + Sync>(pub BitIter<&'a T>);
+pub struct BitProducer<'a, T: 'a + Send + Sync>(pub BitIter<&'a T>, u8);
 
 impl<'a, T: 'a + Send + Sync> UnindexedProducer for BitProducer<'a, T>
     where T: BitSetLike
@@ -49,7 +76,7 @@ impl<'a, T: 'a + Send + Sync> UnindexedProducer for BitProducer<'a, T>
     /// 1) First the highest layer that has at least one set bit
     ///    is searched.
     ///
-    /// 2) If the layer that was found only has one set bit,
+    /// 2) If the layer that was found has only one set bit,
     ///    it's cleared, the correct prefix for the bit is figured
     ///    out and descending is continued.
     ///
@@ -71,6 +98,7 @@ impl<'a, T: 'a + Send + Sync> UnindexedProducer for BitProducer<'a, T>
     /// and thus if all of the bits are set then the smallest possible unit
     /// of work is `usize` bits.
     fn split(mut self) -> (Self, Option<Self>) {
+        let splits = self.1;
         let other = {
             let mut handle_level = |level: usize| if self.0.masks[level] == 0 {
                 None
@@ -81,7 +109,7 @@ impl<'a, T: 'a + Send + Sync> UnindexedProducer for BitProducer<'a, T>
                 average_ones(self.0.masks[level])
                     .and_then(|average_bit| {
                         let mask = (1 << average_bit) - 1;
-                        let mut other = BitProducer(BitIter::new(self.0.set, [0; 4], [0; 3]));
+                        let mut other = BitProducer(BitIter::new(self.0.set, [0; 4], [0; 3]), splits);
                         // `other` is the more significant half of the mask
                         other.0.masks[level] = self.0.masks[level] & !mask;
                         other.0.prefix[level - 1] = (level_prefix | average_bit as u32) << BITS;
@@ -103,9 +131,14 @@ impl<'a, T: 'a + Send + Sync> UnindexedProducer for BitProducer<'a, T>
                         None
                     })
             };
-            handle_level(3)
-                .or_else(|| handle_level(2))
-                .or_else(|| handle_level(1))
+            let mut h = handle_level(3);
+            if splits > 1 {
+                h = h.or_else(|| handle_level(2));
+            }
+            if splits == 3 {
+                h = h.or_else(|| handle_level(1));
+            }
+            h
         };
         (self, other)
     }
@@ -134,16 +167,16 @@ mod test_bit_producer {
 
     use super::BitProducer;
     use iter::BitSetLike;
+    use util::BITS;
 
-    #[test]
-    fn max_splitting_of_two_top_bits() {
+    fn test_splitting(split_levels: u8) {
         fn visit<T>(mut us: BitProducer<T>, d: usize, i: usize, mut trail: String, c: &mut usize)
             where T: Send +
                      Sync +
                      BitSetLike
         {
             if d == 0 {
-                assert!(us.split().1.is_none());
+                assert!(us.split().1.is_none(), trail);
                 *c += 1;
             } else {
                 for j in 1..(i + 1) {
@@ -155,7 +188,7 @@ mod test_bit_producer {
                     visit(them, d, i - j, trail, c);
                 }
                 trail.push_str("u");
-                visit(us, d - 1, 6, trail, c);
+                visit(us, d - 1, BITS, trail, c);
             }
         }
 
@@ -166,12 +199,27 @@ mod test_bit_producer {
             assert!(!c.add(i as u32));
         }
 
-        let us = BitProducer((&c).iter());
+        let us = BitProducer((&c).iter(), split_levels);
         let (us, them) = us.split();
 
         let mut count = 0;
-        visit(us, 2, 6, "u".to_owned(), &mut count);
-        visit(them.expect("Splitting top level"), 2, 6, "t".to_owned(), &mut count);
-        assert_eq!(usize_bits.pow(2) * 2, count);
+        visit(us, split_levels as usize - 1, BITS, "u".to_owned(), &mut count);
+        visit(them.expect("Splitting top level"), split_levels as usize - 1, BITS, "t".to_owned(), &mut count);
+        assert_eq!(usize_bits.pow(split_levels as u32 - 1) * 2, count);
+    }
+
+    #[test]
+    fn max_3_splitting_of_two_top_bits() {
+        test_splitting(3);
+    }
+
+    #[test]
+    fn max_2_splitting_of_two_top_bits() {
+        test_splitting(2);
+    }
+
+    #[test]
+    fn max_1_splitting_of_two_top_bits() {
+        test_splitting(1);
     }
 }

--- a/src/iter/parallel.rs
+++ b/src/iter/parallel.rs
@@ -113,46 +113,6 @@ impl<'a, T: 'a + Send + Sync> UnindexedProducer for BitProducer<'a, T>
     }
 }
 
-#[test]
-fn max_splitting_of_two_top_bits() {
-    fn visit<T>(mut us: BitProducer<T>, d: usize, i: usize, mut trail: String, c: &mut usize)
-        where T: Send +
-                 Sync +
-                 BitSetLike
-    {
-        if d == 0 {
-            assert!(us.split().1.is_none());
-            *c += 1;
-        } else {
-            for j in 1..(i + 1) {
-                let (new_us, them) = us.split();
-                us = new_us;
-                let them = them.expect(&trail);
-                let mut trail = trail.clone();
-                trail.push_str(&i.to_string());
-                visit(them, d, i - j, trail, c);
-            }
-            trail.push_str("u");
-            visit(us, d - 1, 6, trail, c);
-        }
-    }
-
-    let usize_bits = ::std::mem::size_of::<usize>() * 8;
-
-    let mut c = ::BitSet::new();
-    for i in 0..(usize_bits.pow(3) * 2) {
-        assert!(!c.add(i as u32));
-    }
-
-    let us = BitProducer((&c).iter());
-    let (us, them) = us.split();
-
-    let mut count = 0;
-    visit(us, 2, 6, "u".to_owned(), &mut count);
-    visit(them.expect("Splitting top level"), 2, 6, "t".to_owned(), &mut count);
-    assert_eq!(usize_bits.pow(2) * 2, count);
-}
-
 /// Gets usize by layer and index from bit set.
 fn get_from_layer<T: BitSetLike>(set: &T, layer: usize, idx: usize) -> usize {
     match layer {
@@ -161,5 +121,53 @@ fn get_from_layer<T: BitSetLike>(set: &T, layer: usize, idx: usize) -> usize {
         2 => set.layer2(idx),
         3 => set.layer3(),
         _ => unreachable!("Invalid layer {}", layer),
+    }
+}
+
+#[cfg(test)]
+mod test_bit_producer {
+    use rayon::iter::internal::UnindexedProducer;
+
+    use super::BitProducer;
+    use iter::BitSetLike;
+
+    #[test]
+    fn max_splitting_of_two_top_bits() {
+        fn visit<T>(mut us: BitProducer<T>, d: usize, i: usize, mut trail: String, c: &mut usize)
+            where T: Send +
+                    Sync +
+                    BitSetLike
+        {
+            if d == 0 {
+                assert!(us.split().1.is_none());
+                *c += 1;
+            } else {
+                for j in 1..(i + 1) {
+                    let (new_us, them) = us.split();
+                    us = new_us;
+                    let them = them.expect(&trail);
+                    let mut trail = trail.clone();
+                    trail.push_str(&i.to_string());
+                    visit(them, d, i - j, trail, c);
+                }
+                trail.push_str("u");
+                visit(us, d - 1, 6, trail, c);
+            }
+        }
+
+        let usize_bits = ::std::mem::size_of::<usize>() * 8;
+
+        let mut c = ::BitSet::new();
+        for i in 0..(usize_bits.pow(3) * 2) {
+            assert!(!c.add(i as u32));
+        }
+
+        let us = BitProducer((&c).iter());
+        let (us, them) = us.split();
+
+        let mut count = 0;
+        visit(us, 2, 6, "u".to_owned(), &mut count);
+        visit(them.expect("Splitting top level"), 2, 6, "t".to_owned(), &mut count);
+        assert_eq!(usize_bits.pow(2) * 2, count);
     }
 }

--- a/src/iter/parallel.rs
+++ b/src/iter/parallel.rs
@@ -137,9 +137,11 @@ fn max_splitting_of_two_top_bits() {
         }
     }
 
+    let usize_bits = ::std::mem::size_of::<usize>() * 8;
+
     let mut c = ::BitSet::new();
-    for i in 0..524288 {
-        assert!(!c.add(i));
+    for i in 0..(usize_bits.pow(3) * 2) {
+        assert!(!c.add(i as u32));
     }
 
     let us = BitProducer((&c).iter());
@@ -148,7 +150,7 @@ fn max_splitting_of_two_top_bits() {
     let mut count = 0;
     visit(us, 2, 6, "u".to_owned(), &mut count);
     visit(them.expect("Splitting top level"), 2, 6, "t".to_owned(), &mut count);
-    assert_eq!(524288 / 64, count);
+    assert_eq!(usize_bits.pow(2) * 2, count);
 }
 
 /// Gets usize by layer and index from bit set.

--- a/src/util.rs
+++ b/src/util.rs
@@ -56,20 +56,33 @@ pub fn offsets(bit: Index) -> (usize, usize, usize) {
     (bit.offset(SHIFT1), bit.offset(SHIFT2), bit.offset(SHIFT3))
 }
 
-pub fn average_bit(n: usize) -> Option<usize> {
+/// Finds the highest bit that splits ones of the `usize` to half (rounding up).
+///
+/// Returns `None` if the `usize` has only one or zero ones.
+///
+/// # Examples
+/// ````rust,ignore
+/// use hibitset::util::average_ones;
+///
+/// assert_eq!(Some(3), average_ones(0b10110));
+/// assert_eq!(Some(6), average_ones(0b100010));
+/// assert_eq!(None, average_ones(0));
+/// assert_eq!(None, average_ones(1));
+/// ````
+pub fn average_ones(n: usize) -> Option<usize> {
     #[cfg(target_pointer_width= "64")]
     fn average(n: usize) -> Option<usize> {
-        average_bit_u64(n as u64).map(|n| n as usize)
+        average_ones_u64(n as u64).map(|n| n as usize)
     }
     #[cfg(target_pointer_width= "32")]
     fn average(n: usize) -> Option<usize> {
-        average_bit_u64(n as u32).map(|n| n as usize)
+        average_ones_u64(n as u32).map(|n| n as usize)
     }
     average(n)
 }
 
 #[allow(dead_code)]
-fn average_bit_u32(n: u32) -> Option<u32> {
+fn average_ones_u32(n: u32) -> Option<u32> {
     use std::num::Wrapping as W;
     let n = W(n);
     const PAR: [W<u32>; 5] = [
@@ -116,7 +129,7 @@ fn average_bit_u32(n: u32) -> Option<u32> {
 }
 
 #[test]
-fn parity_0_average_bit_u32() {
+fn parity_0_average_ones_u32() {
     struct EvenParity(u32);
 
     impl Iterator for EvenParity {
@@ -140,7 +153,7 @@ fn parity_0_average_bit_u32() {
     for i in 0..steps {
         let pos = i * (u32::max_value() / steps);
         for i in EvenParity(pos).take(steps as usize) {
-            let mask = (1 << (average_bit_u32(i).unwrap_or(32) - 1)) - 1;
+            let mask = (1 << (average_ones_u32(i).unwrap_or(32) - 1)) - 1;
             assert_eq!(
                 (i & mask).count_ones(),
                 (i & !mask).count_ones(),
@@ -151,7 +164,7 @@ fn parity_0_average_bit_u32() {
 }
 
 #[test]
-fn parity_1_average_bit_u32() {
+fn parity_1_average_ones_u32() {
     struct OddParity(u32);
 
     impl Iterator for OddParity {
@@ -175,7 +188,7 @@ fn parity_1_average_bit_u32() {
     for i in 0..steps {
         let pos = i * (u32::max_value() / steps);
         for i in OddParity(pos).take(steps as usize) {
-            let mask = (1 << (average_bit_u32(i).unwrap_or(32) - 1)) - 1;
+            let mask = (1 << (average_ones_u32(i).unwrap_or(32) - 1)) - 1;
             let a = (i & mask).count_ones();
             let b = (i & !mask).count_ones();
             if a < b {
@@ -190,23 +203,23 @@ fn parity_1_average_bit_u32() {
 }
 
 #[test]
-fn empty_average_bit_u32() {
-    assert_eq!(None, average_bit_u32(0));
+fn empty_average_ones_u32() {
+    assert_eq!(None, average_ones_u32(0));
 }
 
 #[test]
-fn singleton_average_bit_u32() {
+fn singleton_average_ones_u32() {
     for i in 0..32 {
         assert_eq!(
             None,
-            average_bit_u32(1 << i),
+            average_ones_u32(1 << i),
             "{:x}", i
         );
     }
 }
 
 #[allow(dead_code)]
-fn average_bit_u64(n: u64) -> Option<u64> {
+fn average_ones_u64(n: u64) -> Option<u64> {
     use std::num::Wrapping as W;
     let n = W(n);
     const PAR: [W<u64>; 6] = [
@@ -257,7 +270,7 @@ fn average_bit_u64(n: u64) -> Option<u64> {
 }
 
 #[test]
-fn parity_0_average_masks_u64() {
+fn parity_0_average_ones_u64() {
     struct EvenParity(u64);
 
     impl Iterator for EvenParity {
@@ -281,7 +294,7 @@ fn parity_0_average_masks_u64() {
     for i in 0..steps {
         let pos = i * (u64::max_value() / steps);
         for i in EvenParity(pos).take(steps as usize) {
-            let mask = (1 << (average_bit_u64(i).unwrap_or(64) - 1)) - 1;
+            let mask = (1 << (average_ones_u64(i).unwrap_or(64) - 1)) - 1;
             assert_eq!(
                 (i & mask).count_ones(),
                 (i & !mask).count_ones(),
@@ -292,7 +305,7 @@ fn parity_0_average_masks_u64() {
 }
 
 #[test]
-fn parity_1_average_bit_u64() {
+fn parity_1_average_ones_u64() {
     struct OddParity(u64);
 
     impl Iterator for OddParity {
@@ -316,7 +329,7 @@ fn parity_1_average_bit_u64() {
     for i in 0..steps {
         let pos = i * (u64::max_value() / steps);
         for i in OddParity(pos).take(steps as usize) {
-            let mask = (1 << (average_bit_u64(i).unwrap_or(64) - 1)) - 1;
+            let mask = (1 << (average_ones_u64(i).unwrap_or(64) - 1)) - 1;
             let a = (i & mask).count_ones();
             let b = (i & !mask).count_ones();
             if a < b {
@@ -331,30 +344,30 @@ fn parity_1_average_bit_u64() {
 }
 
 #[test]
-fn empty_average_bit_u64() {
-    assert_eq!(None, average_bit_u64(0));
+fn empty_average_ones_u64() {
+    assert_eq!(None, average_ones_u64(0));
 }
 
 #[test]
-fn singleton_average_bit_u64() {
+fn singleton_average_ones_u64() {
     for i in 0..64 {
         assert_eq!(
             None,
-            average_bit_u64(1 << i),
+            average_ones_u64(1 << i),
             "{:x}", i
         );
     }
 }
 
 #[test]
-fn average_bits_agree_u32_u64() {
+fn average_ones_agree_u32_u64() {
     let steps = 1000;
     for i in 0..steps {
         let pos = i * (u32::max_value() / steps);
         for i in pos..steps {
             assert_eq!(
-                average_bit_u32(i),
-                average_bit_u64(i as u64).map(|n| n as u32),
+                average_ones_u32(i),
+                average_ones_u64(i as u64).map(|n| n as u32),
                 "{:x}", i
             );
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -56,9 +56,10 @@ pub fn offsets(bit: Index) -> (usize, usize, usize) {
     (bit.offset(SHIFT1), bit.offset(SHIFT2), bit.offset(SHIFT3))
 }
 
-/// Finds the highest bit that splits ones of the `usize` to half (rounding up).
+/// Finds the highest bit that splits set bits of the `usize`
+/// to half (rounding up).
 ///
-/// Returns `None` if the `usize` has only one or zero ones.
+/// Returns `None` if the `usize` has only one or zero set bits.
 ///
 /// # Examples
 /// ````rust,ignore
@@ -69,6 +70,7 @@ pub fn offsets(bit: Index) -> (usize, usize, usize) {
 /// assert_eq!(None, average_ones(0));
 /// assert_eq!(None, average_ones(1));
 /// ````
+// TODO: Can 64/32 bit variants be merged to one implementation?
 pub fn average_ones(n: usize) -> Option<usize> {
     #[cfg(target_pointer_width= "64")]
     fn average(n: usize) -> Option<usize> {
@@ -93,7 +95,7 @@ fn average_ones_u32(n: u32) -> Option<u32> {
         W(0x0000FFFF),
     ];
 
-    // Counting ones in parallel
+    // Counting set bits in parallel
     let a = n - ((n >> 1) & PAR[0]);
     let b = (a & PAR[1]) + ((a >> 2) & PAR[1]);
     let c = (b + (b >> 4)) & PAR[2];
@@ -231,7 +233,7 @@ fn average_ones_u64(n: u64) -> Option<u64> {
         W(0x00000000FFFFFFFF)
     ];
 
-    // Counting ones in parallel
+    // Counting set bits in parallel
     let a = n - ((n >> 1) & PAR[0]);
     let b = (a & PAR[1]) + ((a >> 2) & PAR[1]);
     let c = (b + (b >> 4)) & PAR[2];

--- a/src/util.rs
+++ b/src/util.rs
@@ -55,3 +55,308 @@ impl Row for Index {
 pub fn offsets(bit: Index) -> (usize, usize, usize) {
     (bit.offset(SHIFT1), bit.offset(SHIFT2), bit.offset(SHIFT3))
 }
+
+pub fn average_bit(n: usize) -> Option<usize> {
+    #[cfg(target_pointer_width= "64")]
+    fn average(n: usize) -> Option<usize> {
+        average_bit_u64(n as u64).map(|n| n as usize)
+    }
+    #[cfg(target_pointer_width= "32")]
+    fn average(n: usize) -> Option<usize> {
+        average_bit_u64(n as u32).map(|n| n as usize)
+    }
+    average(n)
+}
+
+#[allow(dead_code)]
+fn average_bit_u32(n: u32) -> Option<u32> {
+    use std::num::Wrapping as W;
+    let n = W(n);
+    const PAR: [W<u32>; 5] = [
+        W(0x55555555),
+        W(0x33333333),
+        W(0x0F0F0F0F),
+        W(0x00FF00FF),
+        W(0x0000FFFF),
+    ];
+
+    // Counting ones in parallel
+    let a = n - ((n >> 1) & PAR[0]);
+    let b = (a & PAR[1]) + ((a >> 2) & PAR[1]);
+    let c = (b + (b >> 4)) & PAR[2];
+    let d = (c + (c >> 8)) & PAR[3];
+    let mut cur = d >> 16;
+    let e = (d + cur) & PAR[4];
+    if e <= W(1) {
+        return None;
+    }
+    let mut target = e / W(2);
+
+    // Branchless binary search
+    let mut result = W(32);
+    {
+        let mut descend = |child, to_bits, child_stride, child_mask| {
+            let diff = cur - target;
+            // If cur < target then result -= (256 >> to_bits)
+            result -= (diff & W(256)) >> to_bits;
+            // If cur < target then target -= t
+            target -= cur & (diff >> 8);
+            // Descend to upper half or lower half
+            // depending on are we over or under
+            cur = (child >> (result - W(child_stride)).0 as usize) & W(child_mask);
+        };
+        descend(c, 4/*16*/,  8, 0b00001111);// PAR[3]
+        descend(b, 5/* 8*/,  4, 0b00000111);// PAR[2]
+        descend(a, 6/* 4*/,  2, 0b00000011);// PAR[1]
+        descend(n, 7/* 2*/,  1, 0b00000001);// PAR[0]
+    }
+    result -= (cur - target & W(256)) >> 8;
+
+    Some(result.0)
+}
+
+#[test]
+fn parity_0_average_bit_u32() {
+    struct EvenParity(u32);
+
+    impl Iterator for EvenParity {
+        type Item = u32;
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.0 == u32::max_value() {
+                return None;
+            }
+            self.0 += 1;
+            while self.0.count_ones() & 1 != 0 {
+                if self.0 == u32::max_value() {
+                    return None;
+                }
+                self.0 += 1;
+            }
+            Some(self.0)
+        }
+    }
+
+    let steps = 1000;
+    for i in 0..steps {
+        let pos = i * (u32::max_value() / steps);
+        for i in EvenParity(pos).take(steps as usize) {
+            let mask = (1 << (average_bit_u32(i).unwrap_or(32) - 1)) - 1;
+            assert_eq!(
+                (i & mask).count_ones(),
+                (i & !mask).count_ones(),
+                "{}", i
+            );
+        }
+    }
+}
+
+#[test]
+fn parity_1_average_bit_u32() {
+    struct OddParity(u32);
+
+    impl Iterator for OddParity {
+        type Item = u32;
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.0 == u32::max_value() {
+                return None;
+            }
+            self.0 += 1;
+            while self.0.count_ones() & 1 == 0 {
+                if self.0 == u32::max_value() {
+                    return None;
+                }
+                self.0 += 1;
+            }
+            Some(self.0)
+        }
+    }
+
+    let steps = 1000;
+    for i in 0..steps {
+        let pos = i * (u32::max_value() / steps);
+        for i in OddParity(pos).take(steps as usize) {
+            let mask = (1 << (average_bit_u32(i).unwrap_or(32) - 1)) - 1;
+            let a = (i & mask).count_ones();
+            let b = (i & !mask).count_ones();
+            if a < b {
+                assert_eq!(a + 1, b, "{:x}", i);
+            } else if b < a{
+                assert_eq!(a, b + 1, "{:x}", i);
+            } else {
+                panic!("Odd parity shouldn't split in exactly half");
+            }
+        }
+    }
+}
+
+#[test]
+fn empty_average_bit_u32() {
+    assert_eq!(None, average_bit_u32(0));
+}
+
+#[test]
+fn singleton_average_bit_u32() {
+    for i in 0..32 {
+        assert_eq!(
+            None,
+            average_bit_u32(1 << i),
+            "{:x}", i
+        );
+    }
+}
+
+#[allow(dead_code)]
+fn average_bit_u64(n: u64) -> Option<u64> {
+    use std::num::Wrapping as W;
+    let n = W(n);
+    const PAR: [W<u64>; 6] = [
+        W(0x5555555555555555),
+        W(0x3333333333333333),
+        W(0x0F0F0F0F0F0F0F0F),
+        W(0x00FF00FF00FF00FF),
+        W(0x0000FFFF0000FFFF),
+        W(0x00000000FFFFFFFF)
+    ];
+
+    // Counting ones in parallel
+    let a = n - ((n >> 1) & PAR[0]);
+    let b = (a & PAR[1]) + ((a >> 2) & PAR[1]);
+    let c = (b + (b >> 4)) & PAR[2];
+    let d = (c + (c >> 8)) & PAR[3];
+    let e = (d + (d >> 16)) & PAR[4];
+    let mut cur = e >> 32;
+    let f = (e + cur) & PAR[5];
+    if f <= W(1) {
+        return None;
+    }
+
+    let mut target = f / W(2);
+
+    // Branchless binary search
+    let mut result = W(64);
+    {
+        let mut descend = |child, to_bits, child_stride, child_mask| {
+            let diff = cur - target;
+            // If cur < target then result -= (256 >> to_bits)
+            result -= (diff & W(256)) >> to_bits;
+            // If cur < target then target -= t
+            target -= cur & (diff >> 8);
+            // Descend to upper half or lower half
+            // depending on are we over or under
+            cur = (child >> (result - W(child_stride)).0 as usize) & W(child_mask);
+        };
+        descend(d, 3/*32*/, 16, 0xFF);// PAR[4]
+        descend(c, 4/*16*/,  8, 0x0F);// PAR[3]
+        descend(b, 5/* 8*/,  4, 0x07);// PAR[2]
+        descend(a, 6/* 4*/,  2, 0x03);// PAR[1]
+        descend(n, 7/* 2*/,  1, 0x01);// PAR[0]
+    }
+    result -= (cur - target & W(256)) >> 8;
+
+    Some(result.0)
+}
+
+#[test]
+fn parity_0_average_masks_u64() {
+    struct EvenParity(u64);
+
+    impl Iterator for EvenParity {
+        type Item = u64;
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.0 == u64::max_value() {
+                return None;
+            }
+            self.0 += 1;
+            while self.0.count_ones() & 1 != 0 {
+                if self.0 == u64::max_value() {
+                    return None;
+                }
+                self.0 += 1;
+            }
+            Some(self.0)
+        }
+    }
+
+    let steps = 1000;
+    for i in 0..steps {
+        let pos = i * (u64::max_value() / steps);
+        for i in EvenParity(pos).take(steps as usize) {
+            let mask = (1 << (average_bit_u64(i).unwrap_or(64) - 1)) - 1;
+            assert_eq!(
+                (i & mask).count_ones(),
+                (i & !mask).count_ones(),
+                "{}", i
+            );
+        }
+    }
+}
+
+#[test]
+fn parity_1_average_bit_u64() {
+    struct OddParity(u64);
+
+    impl Iterator for OddParity {
+        type Item = u64;
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.0 == u64::max_value() {
+                return None;
+            }
+            self.0 += 1;
+            while self.0.count_ones() & 1 == 0 {
+                if self.0 == u64::max_value() {
+                    return None;
+                }
+                self.0 += 1;
+            }
+            Some(self.0)
+        }
+    }
+
+    let steps = 1000;
+    for i in 0..steps {
+        let pos = i * (u64::max_value() / steps);
+        for i in OddParity(pos).take(steps as usize) {
+            let mask = (1 << (average_bit_u64(i).unwrap_or(64) - 1)) - 1;
+            let a = (i & mask).count_ones();
+            let b = (i & !mask).count_ones();
+            if a < b {
+                assert_eq!(a + 1, b, "{:x}", i);
+            } else if b < a{
+                assert_eq!(a, b + 1, "{:x}", i);
+            } else {
+                panic!("Odd parity shouldn't split in exactly half");
+            }
+        }
+    }
+}
+
+#[test]
+fn empty_average_bit_u64() {
+    assert_eq!(None, average_bit_u64(0));
+}
+
+#[test]
+fn singleton_average_bit_u64() {
+    for i in 0..64 {
+        assert_eq!(
+            None,
+            average_bit_u64(1 << i),
+            "{:x}", i
+        );
+    }
+}
+
+#[test]
+fn average_bits_agree_u32_u64() {
+    let steps = 1000;
+    for i in 0..steps {
+        let pos = i * (u32::max_value() / steps);
+        for i in pos..steps {
+            assert_eq!(
+                average_bit_u32(i),
+                average_bit_u64(i as u64).map(|n| n as u32),
+                "{:x}", i
+            );
+        }
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -72,6 +72,7 @@ pub fn offsets(bit: Index) -> (usize, usize, usize) {
 /// ````
 // TODO: Can 64/32 bit variants be merged to one implementation?
 // Seems that this would need integer generics to do.
+#[cfg(feature="parallel")]
 pub fn average_ones(n: usize) -> Option<usize> {
     #[cfg(target_pointer_width = "64")]
     let average = average_ones_u64(n as u64).map(|n| n as usize);
@@ -82,7 +83,7 @@ pub fn average_ones(n: usize) -> Option<usize> {
     average
 }
 
-#[cfg(any(test, target_pointer_width = "32"))]
+#[cfg(all(any(test, target_pointer_width = "32"), feature="parallel"))]
 fn average_ones_u32(n: u32) -> Option<u32> {
     // !0 / ((1 << (1 << n)) | 1)
     const PAR: [u32; 5] = [
@@ -132,7 +133,7 @@ fn average_ones_u32(n: u32) -> Option<u32> {
     Some(result - 1)
 }
 
-#[cfg(any(test, target_pointer_width = "64"))]
+#[cfg(all(any(test, target_pointer_width = "64"), feature="parallel"))]
 fn average_ones_u64(n: u64) -> Option<u64> {
     // !0 / ((1 << (1 << n)) | 1)
     const PAR: [u64; 6] = [
@@ -185,7 +186,7 @@ fn average_ones_u64(n: u64) -> Option<u64> {
     Some(result - 1)
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature="parallel"))]
 mod test_average_ones {
     use super::*;
     #[test]


### PR DESCRIPTION
Improves parallel iterators splitting behaviour and refactors it.

The improvement:
Before 1000000011111111 was split to 10000000 and to 11111111
After 10001111 is split to 10000000111 and to 11111

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/slide-rs/hibitset/19)
<!-- Reviewable:end -->
