### PR TITLE
Add contains methods

### DIFF
--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -172,6 +172,10 @@ impl BitSetLike for AtomicBitSet {
             .map(|l0| l0[o0].load(Ordering::Relaxed))
             .unwrap_or(0)
     }
+    #[inline]
+    fn contains(&self, i: Index) -> bool {
+        self.contains(i)
+    }
 }
 
 impl Default for AtomicBitSet {

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -31,6 +31,13 @@ impl<T> BitIter<T> {
     }
 }
 
+impl<T: BitSetLike> BitIter<T> {
+    /// Allows checking if set bit is contained in underlying bit set.
+    pub fn contains(&self, i: Index) -> bool {
+        self.set.contains(i)
+    }
+}
+
 impl<T> Iterator for BitIter<T>
     where T: BitSetLike
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,9 @@ pub trait BitSetLike {
     /// each index of the set
     fn layer0(&self, i: usize) -> usize;
 
+    /// Allows checking if set bit is contained in the bit set.
+    fn contains(&self, i: Index) -> bool;
+
     /// Create an iterator that will scan over the keyspace
     fn iter(self) -> BitIter<Self>
         where Self: Sized
@@ -236,6 +239,11 @@ impl<'a, T> BitSetLike for &'a T
     fn layer0(&self, i: usize) -> usize {
         (*self).layer0(i)
     }
+
+    #[inline]
+    fn contains(&self, i: Index) -> bool {
+        (*self).contains(i)
+    }
 }
 
 impl BitSetLike for BitSet {
@@ -257,6 +265,11 @@ impl BitSetLike for BitSet {
     #[inline]
     fn layer0(&self, i: usize) -> usize {
         self.layer0.get(i).map(|&x| x).unwrap_or(0)
+    }
+
+    #[inline]
+    fn contains(&self, i: Index) -> bool {
+        self.contains(i)
     }
 }
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -3,6 +3,8 @@ use std::ops::{BitAnd, BitOr, BitXor, Not};
 
 use {BitIter, BitSet, BitSetLike};
 
+use util::*;
+
 /// `BitSetAnd` takes two [`BitSetLike`] items, and merges the masks
 /// returning a new virtual set, which represents an intersection of the
 /// two original sets.
@@ -27,6 +29,10 @@ impl<A: BitSetLike, B: BitSetLike> BitSetLike for BitSetAnd<A, B> {
     #[inline]
     fn layer0(&self, i: usize) -> usize {
         self.0.layer0(i) & self.1.layer0(i)
+    }
+    #[inline]
+    fn contains(&self, i: Index) -> bool {
+        self.0.contains(i) && self.1.contains(i)
     }
 }
 
@@ -55,6 +61,10 @@ impl<A: BitSetLike, B: BitSetLike> BitSetLike for BitSetOr<A, B> {
     fn layer0(&self, i: usize) -> usize {
         self.0.layer0(i) | self.1.layer0(i)
     }
+    #[inline]
+    fn contains(&self, i: Index) -> bool {
+        self.0.contains(i) || self.1.contains(i)
+    }
 }
 
 /// `BitSetNot` takes a [`BitSetLike`] item, and produced an inverted virtual set.
@@ -80,6 +90,10 @@ impl<A: BitSetLike> BitSetLike for BitSetNot<A> {
     #[inline]
     fn layer0(&self, i: usize) -> usize {
         !self.0.layer0(i)
+    }
+    #[inline]
+    fn contains(&self, i: Index) -> bool {
+        !self.0.contains(i)
     }
 }
 
@@ -112,6 +126,11 @@ impl<A: BitSetLike, B: BitSetLike> BitSetLike for BitSetXor<A, B> {
         let xor = BitSetAnd(BitSetOr(&self.0, &self.1), BitSetNot(BitSetAnd(&self.0, &self.1)));
         xor.layer0(id)
     }
+    #[inline]
+    fn contains(&self, i: Index) -> bool {
+        BitSetAnd(BitSetOr(&self.0, &self.1), BitSetNot(BitSetAnd(&self.0, &self.1))).contains(i)
+    }
+
 }
 
 macro_rules! operator {


### PR DESCRIPTION
Adds methods for checking if `BitSetLike` or `BitSetIter` contains set bit in certain index.