### PR TITLE
Refactor the iteration code

### DIFF
--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -54,19 +54,18 @@ impl<T> Iterator for BitIter<T>
         let mut handle_level = |level: usize| if self.masks[level] == 0 {
             Empty
         } else {
-            // Take first bit that isn't zero
+            // Take the first bit that isn't zero
             let first_bit = self.masks[level].trailing_zeros();
-            // Remove it from masks
+            // Remove it from the mask
             self.masks[level] &= !(1 << first_bit);
-            // Calculate index of the bit
+            // Calculate the index of it
             let idx = self.prefix.get(level).cloned().unwrap_or(0) | first_bit;
             if level == 0 {
-                // It's the lowest layer so idx is the next bit in the set
+                // It's the lowest layer, so the `idx` is the next set bit
                 Value(idx)
             } else {
-                // Take corresponding usize from layer below
+                // Take the corresponding `usize` from the layer below
                 self.masks[level - 1] = self.set.get_from_layer(level - 1, idx as usize);
-                // Prefix of the complete index
                 self.prefix[level - 1] = idx << BITS;
                 Continue
             }

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -61,9 +61,9 @@ impl<T> Iterator for BitIter<T>
                 // Remove it from masks
                 self.masks[1] &= !(1 << bit);
                 // Calculate index of the bit in first level
-                let idx = self.prefix[1] | bit;
+                let idx = self.prefix.get(1).cloned().unwrap_or(0) | bit;
                 // Take corresponding usize from layer below
-                self.masks[0] = self.set.layer0(idx as usize);
+                self.masks[0] = get_from_layer(&self.set, 0, idx as usize);
                 // Prefix of the complete index
                 self.prefix[0] = idx << BITS;
                 continue;
@@ -75,9 +75,9 @@ impl<T> Iterator for BitIter<T>
                 // Remove it from masks
                 self.masks[2] &= !(1 << bit);
                 // Calculate index of the bit in second level
-                let idx = self.prefix[2] | bit;
+                let idx = self.prefix.get(2).cloned().unwrap_or(0) | bit;
                 // Take corresponding usize from layer below
-                self.masks[1] = self.set.layer1(idx as usize);
+                self.masks[1] = get_from_layer(&self.set, 1, idx as usize);
                 // Prefix of the index of the second level
                 self.prefix[1] = idx << BITS;
                 continue;
@@ -88,8 +88,10 @@ impl<T> Iterator for BitIter<T>
                 let bit = self.masks[3].trailing_zeros();
                 // Remove it from masks
                 self.masks[3] &= !(1 << bit);
+                // Calculate index of the bit in third level
+                let idx = self.prefix.get(3).cloned().unwrap_or(0) | bit;
                 // Take corresponding usize from layer below
-                self.masks[2] = self.set.layer2(bit as usize);
+                self.masks[2] = get_from_layer(&self.set, 2, idx as usize);
                 // Prefix of the index of the third level
                 self.prefix[2] = bit << BITS;
                 continue;

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -65,7 +65,7 @@ impl<T> Iterator for BitIter<T>
                 Value(idx)
             } else {
                 // Take corresponding usize from layer below
-                self.masks[level - 1] = get_from_layer(&self.set, level - 1, idx as usize);
+                self.masks[level - 1] = self.set.get_from_layer(level - 1, idx as usize);
                 // Prefix of the complete index
                 self.prefix[level - 1] = idx << BITS;
                 Continue

--- a/src/iter/parallel.rs
+++ b/src/iter/parallel.rs
@@ -2,7 +2,7 @@ use rayon::iter::ParallelIterator;
 use rayon::iter::internal::{UnindexedProducer, UnindexedConsumer, Folder, bridge_unindexed};
 
 use iter::{BITS, LAYERS, BitSetLike, BitIter, Index};
-use util::{average_ones, get_from_layer};
+use util::average_ones;
 
 /// A `ParallelIterator` over a [`BitSetLike`] structure.
 ///
@@ -137,7 +137,7 @@ impl<'a, T: 'a + Send + Sync> UnindexedProducer for BitProducer<'a, T>
                         // The level that is descended from doesn't have anything
                         // interesting so it can be skipped in the future.
                         self.0.masks[level] = 0;
-                        self.0.masks[level - 1] = get_from_layer(self.0.set, level - 1, idx);
+                        self.0.masks[level - 1] = self.0.set.get_from_layer(level - 1, idx);
                         None
                     })
             };

--- a/src/iter/parallel.rs
+++ b/src/iter/parallel.rs
@@ -2,7 +2,7 @@ use rayon::iter::ParallelIterator;
 use rayon::iter::internal::{UnindexedProducer, UnindexedConsumer, Folder, bridge_unindexed};
 
 use iter::{BITS, LAYERS, BitSetLike, BitIter, Index};
-use util::average_ones;
+use util::{average_ones, get_from_layer};
 
 /// A `ParallelIterator` over a [`BitSetLike`] structure.
 ///
@@ -155,17 +155,6 @@ impl<'a, T: 'a + Send + Sync> UnindexedProducer for BitProducer<'a, T>
         where F: Folder<Self::Item>
     {
         folder.consume_iter(self.0)
-    }
-}
-
-/// Gets usize by a layer and an index from the bitset.
-fn get_from_layer<T: BitSetLike>(set: &T, layer: usize, idx: usize) -> usize {
-    match layer {
-        0 => set.layer0(idx),
-        1 => set.layer1(idx),
-        2 => set.layer2(idx),
-        3 => set.layer3(),
-        _ => panic!("Invalid layer {}", layer),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,19 +180,32 @@ impl BitSet {
 ///
 /// [`BitSetLike`]: ../trait.BitSetLike.html
 pub trait BitSetLike {
-    /// Return a usize where each bit represents if any word in layer2
+    /// Gets the `usize` corresponding to layer and index.
+    ///
+    /// The `layer` should be in the range [0, 3]
+    fn get_from_layer(&self, layer: usize, idx: usize) -> usize {
+        match layer {
+            0 => self.layer0(idx),
+            1 => self.layer1(idx),
+            2 => self.layer2(idx),
+            3 => self.layer3(),
+            _ => panic!("Invalid layer: {}", layer),
+        }
+    }
+
+    /// Return a `usize` where each bit represents if any word in layer2
     /// has been set.
     fn layer3(&self) -> usize;
 
-    /// Return the usize from the array of usizes that indicates if any
+    /// Return the `usize` from the array of usizes that indicates if any
     /// bit has been set in layer1
     fn layer2(&self, i: usize) -> usize;
 
-    /// Return the usize from the array of usizes that indicates if any
+    /// Return the `usize` from the array of usizes that indicates if any
     /// bit has been set in layer0
     fn layer1(&self, i: usize) -> usize;
 
-    /// Return a usize that maps to the direct 1:1 association with
+    /// Return a `usize` that maps to the direct 1:1 association with
     /// each index of the set
     fn layer0(&self, i: usize) -> usize;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,3 @@
-use BitSetLike;
 
 /// Type used for indexing.
 pub type Index = u32;
@@ -55,17 +54,6 @@ impl Row for Index {
 #[inline]
 pub fn offsets(bit: Index) -> (usize, usize, usize) {
     (bit.offset(SHIFT1), bit.offset(SHIFT2), bit.offset(SHIFT3))
-}
-
-/// Gets the `usize` corresponding to layer and index
-pub fn get_from_layer<T: BitSetLike>(set: &T, layer: usize, idx: usize) -> usize {
-    match layer {
-        0 => set.layer0(idx),
-        1 => set.layer1(idx),
-        2 => set.layer2(idx),
-        3 => set.layer3(),
-        _ => panic!("Invalid layer {}", layer),
-    }
 }
 
 /// Finds the highest bit that splits set bits of the `usize`

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,4 @@
+use BitSetLike;
 
 /// Type used for indexing.
 pub type Index = u32;
@@ -54,6 +55,17 @@ impl Row for Index {
 #[inline]
 pub fn offsets(bit: Index) -> (usize, usize, usize) {
     (bit.offset(SHIFT1), bit.offset(SHIFT2), bit.offset(SHIFT3))
+}
+
+/// Gets the `usize` corresponding to layer and index
+pub fn get_from_layer<T: BitSetLike>(set: &T, layer: usize, idx: usize) -> usize {
+    match layer {
+        0 => set.layer0(idx),
+        1 => set.layer1(idx),
+        2 => set.layer2(idx),
+        3 => set.layer3(),
+        _ => panic!("Invalid layer {}", layer),
+    }
 }
 
 /// Finds the highest bit that splits set bits of the `usize`


### PR DESCRIPTION
The parallel iterator PR that was merged was originally supposed to just contain documentation changes and this refactor that I wanted to do. I got bit sidetracked when I realised that I could make the splitting better.

(I just love how closures can be used to do these kinds of refactors*)

*and then you move the closure to a method