### PR TITLE
Implement BitSetLike on BitSetLike trait object

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,7 @@ pub trait DrainableBitSet: BitSetLike {
 
 impl<'a, T> BitSetLike for &'a T
 where
-    T: BitSetLike,
+    T: BitSetLike + ?Sized,
 {
     #[inline]
     fn layer3(&self) -> usize {
@@ -355,62 +355,8 @@ where
 
 impl<'a, T> BitSetLike for &'a mut T
 where
-    T: BitSetLike,
+    T: BitSetLike + ?Sized,
 {
-    #[inline]
-    fn layer3(&self) -> usize {
-        (**self).layer3()
-    }
-
-    #[inline]
-    fn layer2(&self, i: usize) -> usize {
-        (**self).layer2(i)
-    }
-
-    #[inline]
-    fn layer1(&self, i: usize) -> usize {
-        (**self).layer1(i)
-    }
-
-    #[inline]
-    fn layer0(&self, i: usize) -> usize {
-        (**self).layer0(i)
-    }
-
-    #[inline]
-    fn contains(&self, i: Index) -> bool {
-        (**self).contains(i)
-    }
-}
-
-impl<'a> BitSetLike for &'a dyn BitSetLike {
-    #[inline]
-    fn layer3(&self) -> usize {
-        (*self).layer3()
-    }
-
-    #[inline]
-    fn layer2(&self, i: usize) -> usize {
-        (*self).layer2(i)
-    }
-
-    #[inline]
-    fn layer1(&self, i: usize) -> usize {
-        (*self).layer1(i)
-    }
-
-    #[inline]
-    fn layer0(&self, i: usize) -> usize {
-        (*self).layer0(i)
-    }
-
-    #[inline]
-    fn contains(&self, i: Index) -> bool {
-        (*self).contains(i)
-    }
-}
-
-impl<'a> BitSetLike for &'a mut dyn BitSetLike {
     #[inline]
     fn layer3(&self) -> usize {
         (**self).layer3()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,6 +383,60 @@ where
     }
 }
 
+impl<'a> BitSetLike for &'a dyn BitSetLike {
+    #[inline]
+    fn layer3(&self) -> usize {
+        (*self).layer3()
+    }
+
+    #[inline]
+    fn layer2(&self, i: usize) -> usize {
+        (*self).layer2(i)
+    }
+
+    #[inline]
+    fn layer1(&self, i: usize) -> usize {
+        (*self).layer1(i)
+    }
+
+    #[inline]
+    fn layer0(&self, i: usize) -> usize {
+        (*self).layer0(i)
+    }
+
+    #[inline]
+    fn contains(&self, i: Index) -> bool {
+        (*self).contains(i)
+    }
+}
+
+impl<'a> BitSetLike for &'a mut dyn BitSetLike {
+    #[inline]
+    fn layer3(&self) -> usize {
+        (**self).layer3()
+    }
+
+    #[inline]
+    fn layer2(&self, i: usize) -> usize {
+        (**self).layer2(i)
+    }
+
+    #[inline]
+    fn layer1(&self, i: usize) -> usize {
+        (**self).layer1(i)
+    }
+
+    #[inline]
+    fn layer0(&self, i: usize) -> usize {
+        (**self).layer0(i)
+    }
+
+    #[inline]
+    fn contains(&self, i: Index) -> bool {
+        (**self).contains(i)
+    }
+}
+
 impl<'a, T> DrainableBitSet for &'a mut T
 where
     T: DrainableBitSet,


### PR DESCRIPTION
These changes are the first step in enabling support for conditionally choosing a `BitSetLike` to use in a `Join`. The second set of changes will be in the  `specs` crate: implementing `Join` on the `BitSetLike` trait object.

With both sets of changes, this sort of thing is possible:
```rust
let first = BitSet::new();
let second = !&first;
let cond = true;
let bitset: &dyn BitSetLike = if cond {
    &first
} else {
    &second
};
bitset.join();
```