### PR TITLE
Remove extraneous 'self.layer0[p0] |= mask;' line in BitSet::add()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,8 +144,6 @@ impl BitSet {
         self.layer0[p0] |= mask;
         if old == 0 {
             self.add_slow(id);
-        } else {
-            self.layer0[p0] |= mask;
         }
         false
     }


### PR DESCRIPTION
Couldn't tell what's going on here so there absolutely could be something I missed and the else branch is needed.

It looks like at some point the layer0 set was factored out of the branch (since it happens for both cases) without deleting the else branch which is now a no-op.

All tests passed with this change.