### PR TITLE
Added optional serde support, including an example in the README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,14 @@ atom = "0.3"
 version = "1.3"
 optional = true
 
+[dependencies.serde]
+version = "1.0.111"
+optional = true
+
 [dev-dependencies]
 rand = "0.7"
 
 [features]
 default = ["parallel"]
 parallel = ["rayon"]
+derive = ["serde"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # hibitset
+
 [![Build Status](https://travis-ci.org/slide-rs/hibitset.svg)](https://travis-ci.org/slide-rs/hibitset)
 [![Crates.io](https://img.shields.io/crates/v/hibitset.svg?maxAge=2592000)](https://crates.io/crates/hibitset)
 
-Provides hierarchical bit sets, which allow very fast iteration on 
+Provides hierarchical bit sets, which allow very fast iteration on
 sparse data structures.
 
 ## Usage
@@ -14,9 +15,49 @@ Just add this to your `Cargo.toml`:
 hibitset = "0.6"
 ```
 
+## Using the `serde` feature
+
+There is an optional feature to use `serde` for serialization/deserializtion. To enable this feature add the following to your `Cargo.toml`:
+
+```
+[dependencies]
+hibitset = { version = "0.6.3", features = ["serde"]}
+serde_derive = "1.0.111"
+serde = "1.0.111"
+bincode = "1.2.1"
+```
+
+Using `bincode` here is an example of how you can serialize/deserialize a `BitSet`:
+
+```
+#[macro_use]
+extern crate serde_derive;
+
+use hibitset::{BitSet, BitSetAnd, BitSetLike, BitSetNot};
+use bincode;
+
+fn main() {
+    let mut set1 = BitSet::new();
+
+    for i in 0..10 {
+        set1.add(i * 2);
+    }
+
+    let serde_len = bincode::serialized_size(&set1).unwrap();
+    let set1_buf = bincode::serialize(&set1).unwrap();
+
+    let result_set1: BitSet = bincode::deserialize(&set1_buf).unwrap();
+
+}
+```
+
 ## License
 
 This library is licensed under the Apache License 2.0,
 see [the LICENSE file][li] for more information.
 
 [li]: LICENSE
+
+```
+
+```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Using `bincode` here is an example of how you can serialize/deserialize a `BitSe
 #[macro_use]
 extern crate serde_derive;
 
-use hibitset::{BitSet, BitSetAnd, BitSetLike, BitSetNot};
+use hibitset::{BitSet};
 use bincode;
 
 fn main() {

--- a/README.md
+++ b/README.md
@@ -57,7 +57,3 @@ This library is licensed under the Apache License 2.0,
 see [the LICENSE file][li] for more information.
 
 [li]: LICENSE
-
-```
-
-```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,11 @@ extern crate rand;
 #[cfg(feature = "parallel")]
 extern crate rayon;
 
+#[cfg(feature = "serde")]
+extern crate serde;
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
+
 mod atomic;
 mod iter;
 mod ops;
@@ -70,6 +75,7 @@ use util::*;
 /// Note, a `BitSet` is limited by design to only `usize**4` indices.
 /// Adding beyond this limit will cause the `BitSet` to panic.
 #[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BitSet {
     layer3: usize,
     layer2: Vec<usize>,
@@ -867,4 +873,5 @@ mod test_parallel {
             );
         }
     }
+
 }


### PR DESCRIPTION
Here is the PR for the `serde` feature. I added a simple example using `bincode` in the README. There is no test, I could do that easily but it would mean adding another dev dependency, not sure if you wanted that in the codebase. 

The version has not been changed, that should be done if you decide this to put it in a release.