### PR TITLE
Fix UB reported by miri in AtomicBitSet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,6 @@ categories = ["data-structures"]
 license = "MIT/Apache-2.0"
 authors = ["csheratt"]
 
-[dependencies]
-atom = "0.3"
-
 [dependencies.rayon]
 version = "1.3"
 optional = true

--- a/src/iter/parallel.rs
+++ b/src/iter/parallel.rs
@@ -181,7 +181,7 @@ mod test_bit_producer {
             T: Send + Sync + BitSetLike,
         {
             if d == 0 {
-                assert!(us.split().1.is_none(), trail);
+                assert!(us.split().1.is_none(), "{}", trail);
                 *c += 1;
             } else {
                 for j in 1..(i + 1) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,6 @@
 
 #![deny(missing_docs)]
 
-extern crate atom;
 #[cfg(test)]
 extern crate rand;
 #[cfg(feature = "parallel")]


### PR DESCRIPTION
* Also modify some spots that have `&mut self` to use `get_mut` instead of atomic ops.

Miri reports UB for `atom::AtomSetOnce::get` (used internally in `AtomicBitSet`) since it gets a pointer from a Box via dereference and then `mem::forget`s the Box which moves the Box (invalidating the pointer since the Box pointer is "unique").

Since we aren't using anything else from the `atom` crate (and it has several other open soundness issues) it is far simpler to provide a minimal implementation of what we need here. `once_cell::race::OnceBox` is close to what we need here but doesn't provide `get_mut` and due to its current MSRV has stronger than necessary ordering for the compare_exchange failure case.