### PR TITLE
AtomicBitSet Debug crashes

### DIFF
--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -483,4 +483,10 @@ mod atomic_set_test {
         set.clear();
         assert_eq!((&set).iter().count(), 0);
     }
+
+    #[test]
+    fn debug() {
+        let bitset = AtomicBitSet::default();
+        println!("debug = {:?}", bitset);
+    }
 }


### PR DESCRIPTION
This crashes...

```rust
use hibitset::AtomicBitSet;

fn main() {
    let bitset = AtomicBitSet::new();
    println!("bitset = {:?}", bitset);
}
```

The proposed fix implements Debug for AtomicBlock so that the error doesn't happen - please check the output to make sure it is what you want it to be for internal debugging.
It also implements AtomicBitSet Debug manually to be the output of `iter()` - which I felt was more helpful to users of the library.  
