### PR TITLE
Generalize integer type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ optional = true
 
 [dev-dependencies]
 rand = "0.7"
+typed_test_gen = "0.1"
 
 [features]
 default = ["parallel"]

--- a/src/iter/drain.rs
+++ b/src/iter/drain.rs
@@ -1,11 +1,11 @@
 use iter::BitIter;
 use util::*;
-use DrainableBitSet;
+use {BitSetLike, DrainableBitSet};
 
 /// A draining `Iterator` over a [`DrainableBitSet`] structure.
 ///
 /// [`DrainableBitSet`]: ../trait.DrainableBitSet.html
-pub struct DrainBitIter<'a, T: 'a> {
+pub struct DrainBitIter<'a, T: 'a + BitSetLike> {
     iter: BitIter<&'a mut T>,
 }
 
@@ -14,7 +14,7 @@ impl<'a, T: DrainableBitSet> DrainBitIter<'a, T> {
     /// but just [`.drain()`] on a bit set.
     ///
     /// [`.drain()`]: ../trait.DrainableBitSet.html#method.drain
-    pub fn new(set: &'a mut T, masks: [usize; LAYERS], prefix: [u32; LAYERS - 1]) -> Self {
+    pub fn new(set: &'a mut T, masks: [T::Underlying; LAYERS], prefix: [u32; LAYERS - 1]) -> Self {
         DrainBitIter {
             iter: BitIter::new(set, masks, prefix),
         }
@@ -36,10 +36,16 @@ where
     }
 }
 
-#[test]
-fn drain_all() {
-    use {BitSet, BitSetLike};
-    let mut bit_set: BitSet = (0..10000).filter(|i| i % 2 == 0).collect();
-    bit_set.drain().for_each(|_| {});
-    assert_eq!(0, bit_set.iter().count());
+#[cfg(test)]
+mod tests {
+    extern crate typed_test_gen;
+    use self::typed_test_gen::test_with;
+    use {BitSetLike, DrainableBitSet, GenericBitSet, UnsignedInteger};
+
+    #[test_with(u32, u64, usize)]
+    fn drain_all<T: UnsignedInteger>() {
+        let mut bit_set: GenericBitSet<T> = (0..10000).filter(|i| i % 2 == 0).collect();
+        bit_set.drain().for_each(|_| {});
+        assert_eq!(0, bit_set.iter().count());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,10 +37,10 @@
 //! below it can be skipped.)
 //!
 //! However, there is a maximum on index size. The top layer (Layer 3)
-//! of the BitSet is a single `usize` long. This makes the maximum index
-//! `usize**4` (`1,048,576` for a 32-bit `usize`, `16,777,216` for a
-//! 64-bit `usize`). Attempting to add indices larger than that will cause
-//! the `BitSet` to panic.
+//! of the BitSet is a single integer long (depending on the underlying type used).
+//! This makes the maximum index `BITS**4` (`1,048,576` for a 32-bit `usize`,
+//! `16,777,216` for a 64-bit `usize`). Attempting to add indices larger than that
+//! will cause the `BitSet` to panic.
 //!
 
 #![deny(missing_docs)]
@@ -63,36 +63,48 @@ pub use ops::{BitSetAll, BitSetAnd, BitSetNot, BitSetOr, BitSetXor};
 
 use util::*;
 
+/// A `GenericBitSet` is a simple set designed to track which indices are placed
+/// into it. Is is based on an underlying type `T` which is supposed to represent an
+/// unsigned integer type (in particular `u32`, `u64`, or `usize`).
+///
+/// Note, a `BitSet` is limited by design to only `T::NB_BITS**4` indices.
+/// Adding beyond this limit will cause the `BitSet` to panic.
+#[derive(Clone, Debug, Default)]
+pub struct GenericBitSet<T: UnsignedInteger> {
+    layer3: T,
+    layer2: Vec<T>,
+    layer1: Vec<T>,
+    layer0: Vec<T>,
+}
+
 /// A `BitSet` is a simple set designed to track which indices are placed
 /// into it.
 ///
 /// Note, a `BitSet` is limited by design to only `usize**4` indices.
 /// Adding beyond this limit will cause the `BitSet` to panic.
-#[derive(Clone, Debug, Default)]
-pub struct BitSet {
-    layer3: usize,
-    layer2: Vec<usize>,
-    layer1: Vec<usize>,
-    layer0: Vec<usize>,
-}
+pub type BitSet = GenericBitSet<usize>;
 
-impl BitSet {
+impl<T: UnsignedInteger> GenericBitSet<T> {
     /// Creates an empty `BitSet`.
-    pub fn new() -> BitSet {
+    pub fn new() -> Self {
         Default::default()
     }
 
     #[inline]
     fn valid_range(max: Index) {
-        if (MAX_EID as u32) < max {
-            panic!("Expected index to be less then {}, found {}", MAX_EID, max);
+        if T::MAX_EID < max {
+            panic!(
+                "Expected index to be less then {}, found {}",
+                T::MAX_EID,
+                max
+            );
         }
     }
 
     /// Creates an empty `BitSet`, preallocated for up to `max` indices.
-    pub fn with_capacity(max: Index) -> BitSet {
+    pub fn with_capacity(max: Index) -> Self {
         Self::valid_range(max);
-        let mut value = BitSet::new();
+        let mut value = Self::new();
         value.extend(max);
         value
     }
@@ -100,16 +112,16 @@ impl BitSet {
     #[inline(never)]
     fn extend(&mut self, id: Index) {
         Self::valid_range(id);
-        let (p0, p1, p2) = offsets(id);
+        let (p0, p1, p2) = offsets::<T>(id);
 
         Self::fill_up(&mut self.layer2, p2);
         Self::fill_up(&mut self.layer1, p1);
         Self::fill_up(&mut self.layer0, p0);
     }
 
-    fn fill_up(vec: &mut Vec<usize>, upper_index: usize) {
+    fn fill_up(vec: &mut Vec<T>, upper_index: usize) {
         if vec.len() <= upper_index {
-            vec.resize(upper_index + 1, 0);
+            vec.resize(upper_index + 1, T::ZERO);
         }
     }
 
@@ -117,23 +129,23 @@ impl BitSet {
     /// when the lowest layer was set from 0.
     #[inline(never)]
     fn add_slow(&mut self, id: Index) {
-        let (_, p1, p2) = offsets(id);
-        self.layer1[p1] |= id.mask(SHIFT1);
-        self.layer2[p2] |= id.mask(SHIFT2);
-        self.layer3 |= id.mask(SHIFT3);
+        let (_, p1, p2) = offsets::<T>(id);
+        self.layer1[p1] |= id.mask::<T>(T::SHIFT1);
+        self.layer2[p2] |= id.mask::<T>(T::SHIFT2);
+        self.layer3 |= id.mask::<T>(T::SHIFT3);
     }
 
     /// Adds `id` to the `BitSet`. Returns `true` if the value was
     /// already in the set.
     #[inline]
     pub fn add(&mut self, id: Index) -> bool {
-        let (p0, mask) = (id.offset(SHIFT1), id.mask(SHIFT0));
+        let (p0, mask) = (id.offset(T::SHIFT1), id.mask::<T>(T::SHIFT0));
 
         if p0 >= self.layer0.len() {
             self.extend(id);
         }
 
-        if self.layer0[p0] & mask != 0 {
+        if self.layer0[p0] & mask != T::ZERO {
             return true;
         }
 
@@ -141,13 +153,13 @@ impl BitSet {
         // that the value can be found here.
         let old = self.layer0[p0];
         self.layer0[p0] |= mask;
-        if old == 0 {
+        if old == T::ZERO {
             self.add_slow(id);
         }
         false
     }
 
-    fn layer_mut(&mut self, level: usize, idx: usize) -> &mut usize {
+    fn layer_mut(&mut self, level: usize, idx: usize) -> &mut T {
         match level {
             0 => {
                 Self::fill_up(&mut self.layer0, idx);
@@ -171,13 +183,13 @@ impl BitSet {
     /// to begin with.
     #[inline]
     pub fn remove(&mut self, id: Index) -> bool {
-        let (p0, p1, p2) = offsets(id);
+        let (p0, p1, p2) = offsets::<T>(id);
 
         if p0 >= self.layer0.len() {
             return false;
         }
 
-        if self.layer0[p0] & id.mask(SHIFT0) == 0 {
+        if self.layer0[p0] & id.mask::<T>(T::SHIFT0) == T::ZERO {
             return false;
         }
 
@@ -185,35 +197,38 @@ impl BitSet {
         // its bit from layer0 to 3. the layers abover only
         // should be cleared if the bit cleared was the last bit
         // in its set
-        self.layer0[p0] &= !id.mask(SHIFT0);
-        if self.layer0[p0] != 0 {
+        self.layer0[p0] &= !id.mask::<T>(T::SHIFT0);
+        if self.layer0[p0] != T::ZERO {
             return true;
         }
 
-        self.layer1[p1] &= !id.mask(SHIFT1);
-        if self.layer1[p1] != 0 {
+        self.layer1[p1] &= !id.mask::<T>(T::SHIFT1);
+        if self.layer1[p1] != T::ZERO {
             return true;
         }
 
-        self.layer2[p2] &= !id.mask(SHIFT2);
-        if self.layer2[p2] != 0 {
+        self.layer2[p2] &= !id.mask::<T>(T::SHIFT2);
+        if self.layer2[p2] != T::ZERO {
             return true;
         }
 
-        self.layer3 &= !id.mask(SHIFT3);
+        self.layer3 &= !id.mask::<T>(T::SHIFT3);
         return true;
     }
 
     /// Returns `true` if `id` is in the set.
     #[inline]
     pub fn contains(&self, id: Index) -> bool {
-        let p0 = id.offset(SHIFT1);
-        p0 < self.layer0.len() && (self.layer0[p0] & id.mask(SHIFT0)) != 0
+        let p0 = id.offset(T::SHIFT1);
+        p0 < self.layer0.len() && (self.layer0[p0] & id.mask::<T>(T::SHIFT0)) != T::ZERO
     }
 
     /// Returns `true` if all ids in `other` are contained in this set
     #[inline]
-    pub fn contains_set(&self, other: &BitSet) -> bool {
+    pub fn contains_set<S>(&self, other: &S) -> bool
+    where
+        S: BitSetLike<Underlying = T>,
+    {
         for id in other.iter() {
             if !self.contains(id) {
                 return false;
@@ -227,7 +242,7 @@ impl BitSet {
         self.layer0.clear();
         self.layer1.clear();
         self.layer2.clear();
-        self.layer3 = 0;
+        self.layer3 = T::ZERO;
     }
 
     /// How many bits are in a `usize`.
@@ -282,7 +297,7 @@ impl BitSet {
     ///
     /// assert_eq!(slice[slice_index], 1 << bit_at_index);
     /// ```
-    pub fn layer0_as_slice(&self) -> &[usize] {
+    pub fn layer0_as_slice(&self) -> &[T] {
         self.layer0.as_slice()
     }
 
@@ -328,7 +343,7 @@ impl BitSet {
     ///
     /// assert_eq!(slice[slice_index], 1 << bit_at_index);
     /// ```
-    pub fn layer1_as_slice(&self) -> &[usize] {
+    pub fn layer1_as_slice(&self) -> &[T] {
         self.layer1.as_slice()
     }
 
@@ -373,7 +388,7 @@ impl BitSet {
     ///
     /// assert_eq!(slice[slice_index], 1 << bit_at_index);
     /// ```
-    pub fn layer2_as_slice(&self) -> &[usize] {
+    pub fn layer2_as_slice(&self) -> &[T] {
         self.layer2.as_slice()
     }
 }
@@ -392,10 +407,13 @@ impl BitSet {
 ///
 /// [`BitSetLike`]: ../trait.BitSetLike.html
 pub trait BitSetLike {
+    /// Type of the underlying bit storage
+    type Underlying: UnsignedInteger;
+
     /// Gets the `usize` corresponding to layer and index.
     ///
     /// The `layer` should be in the range [0, 3]
-    fn get_from_layer(&self, layer: usize, idx: usize) -> usize {
+    fn get_from_layer(&self, layer: usize, idx: usize) -> Self::Underlying {
         match layer {
             0 => self.layer0(idx),
             1 => self.layer1(idx),
@@ -407,24 +425,24 @@ pub trait BitSetLike {
 
     /// Returns true if this `BitSetLike` contains nothing, and false otherwise.
     fn is_empty(&self) -> bool {
-        self.layer3() == 0
+        self.layer3() == Self::Underlying::ZERO
     }
 
     /// Return a `usize` where each bit represents if any word in layer2
     /// has been set.
-    fn layer3(&self) -> usize;
+    fn layer3(&self) -> Self::Underlying;
 
     /// Return the `usize` from the array of usizes that indicates if any
     /// bit has been set in layer1
-    fn layer2(&self, i: usize) -> usize;
+    fn layer2(&self, i: usize) -> Self::Underlying;
 
     /// Return the `usize` from the array of usizes that indicates if any
     /// bit has been set in layer0
-    fn layer1(&self, i: usize) -> usize;
+    fn layer1(&self, i: usize) -> Self::Underlying;
 
     /// Return a `usize` that maps to the direct 1:1 association with
     /// each index of the set
-    fn layer0(&self, i: usize) -> usize;
+    fn layer0(&self, i: usize) -> Self::Underlying;
 
     /// Allows checking if set bit is contained in the bit set.
     fn contains(&self, i: Index) -> bool;
@@ -436,7 +454,16 @@ pub trait BitSetLike {
     {
         let layer3 = self.layer3();
 
-        BitIter::new(self, [0, 0, 0, layer3], [0; LAYERS - 1])
+        BitIter::new(
+            self,
+            [
+                Self::Underlying::ZERO,
+                Self::Underlying::ZERO,
+                Self::Underlying::ZERO,
+                layer3,
+            ],
+            [0; LAYERS - 1],
+        )
     }
 
     /// Create a parallel iterator that will scan over the keyspace
@@ -463,7 +490,16 @@ pub trait DrainableBitSet: BitSetLike {
     {
         let layer3 = self.layer3();
 
-        DrainBitIter::new(self, [0, 0, 0, layer3], [0; LAYERS - 1])
+        DrainBitIter::new(
+            self,
+            [
+                Self::Underlying::ZERO,
+                Self::Underlying::ZERO,
+                Self::Underlying::ZERO,
+                layer3,
+            ],
+            [0; LAYERS - 1],
+        )
     }
 }
 
@@ -471,23 +507,25 @@ impl<'a, T> BitSetLike for &'a T
 where
     T: BitSetLike + ?Sized,
 {
+    type Underlying = T::Underlying;
+
     #[inline]
-    fn layer3(&self) -> usize {
+    fn layer3(&self) -> T::Underlying {
         (*self).layer3()
     }
 
     #[inline]
-    fn layer2(&self, i: usize) -> usize {
+    fn layer2(&self, i: usize) -> T::Underlying {
         (*self).layer2(i)
     }
 
     #[inline]
-    fn layer1(&self, i: usize) -> usize {
+    fn layer1(&self, i: usize) -> T::Underlying {
         (*self).layer1(i)
     }
 
     #[inline]
-    fn layer0(&self, i: usize) -> usize {
+    fn layer0(&self, i: usize) -> T::Underlying {
         (*self).layer0(i)
     }
 
@@ -501,23 +539,25 @@ impl<'a, T> BitSetLike for &'a mut T
 where
     T: BitSetLike + ?Sized,
 {
+    type Underlying = T::Underlying;
+
     #[inline]
-    fn layer3(&self) -> usize {
+    fn layer3(&self) -> T::Underlying {
         (**self).layer3()
     }
 
     #[inline]
-    fn layer2(&self, i: usize) -> usize {
+    fn layer2(&self, i: usize) -> T::Underlying {
         (**self).layer2(i)
     }
 
     #[inline]
-    fn layer1(&self, i: usize) -> usize {
+    fn layer1(&self, i: usize) -> T::Underlying {
         (**self).layer1(i)
     }
 
     #[inline]
-    fn layer0(&self, i: usize) -> usize {
+    fn layer0(&self, i: usize) -> T::Underlying {
         (**self).layer0(i)
     }
 
@@ -537,25 +577,27 @@ where
     }
 }
 
-impl BitSetLike for BitSet {
+impl<T: UnsignedInteger> BitSetLike for GenericBitSet<T> {
+    type Underlying = T;
+
     #[inline]
-    fn layer3(&self) -> usize {
+    fn layer3(&self) -> T {
         self.layer3
     }
 
     #[inline]
-    fn layer2(&self, i: usize) -> usize {
-        self.layer2.get(i).map(|&x| x).unwrap_or(0)
+    fn layer2(&self, i: usize) -> T {
+        self.layer2.get(i).map(|&x| x).unwrap_or(T::ZERO)
     }
 
     #[inline]
-    fn layer1(&self, i: usize) -> usize {
-        self.layer1.get(i).map(|&x| x).unwrap_or(0)
+    fn layer1(&self, i: usize) -> T {
+        self.layer1.get(i).map(|&x| x).unwrap_or(T::ZERO)
     }
 
     #[inline]
-    fn layer0(&self, i: usize) -> usize {
-        self.layer0.get(i).map(|&x| x).unwrap_or(0)
+    fn layer0(&self, i: usize) -> T {
+        self.layer0.get(i).map(|&x| x).unwrap_or(T::ZERO)
     }
 
     #[inline]
@@ -564,16 +606,16 @@ impl BitSetLike for BitSet {
     }
 }
 
-impl DrainableBitSet for BitSet {
+impl<T: UnsignedInteger> DrainableBitSet for GenericBitSet<T> {
     #[inline]
     fn remove(&mut self, i: Index) -> bool {
         self.remove(i)
     }
 }
 
-impl PartialEq for BitSet {
+impl<T: UnsignedInteger> PartialEq for GenericBitSet<T> {
     #[inline]
-    fn eq(&self, rhv: &BitSet) -> bool {
+    fn eq(&self, rhv: &GenericBitSet<T>) -> bool {
         if self.layer3 != rhv.layer3 {
             return false;
         }
@@ -603,15 +645,18 @@ impl PartialEq for BitSet {
         true
     }
 }
-impl Eq for BitSet {}
+impl<T: UnsignedInteger> Eq for GenericBitSet<T> {}
 
 #[cfg(test)]
 mod tests {
-    use super::{BitSet, BitSetAnd, BitSetLike, BitSetNot};
+    extern crate typed_test_gen;
+    use self::typed_test_gen::test_with;
 
-    #[test]
-    fn insert() {
-        let mut c = BitSet::new();
+    use super::{BitSetAnd, BitSetLike, BitSetNot, GenericBitSet, UnsignedInteger};
+
+    #[test_with(u32, u64, usize)]
+    fn insert<T: UnsignedInteger>() {
+        let mut c = GenericBitSet::<T>::new();
         for i in 0..1_000 {
             assert!(!c.add(i));
             assert!(c.add(i));
@@ -622,9 +667,9 @@ mod tests {
         }
     }
 
-    #[test]
-    fn insert_100k() {
-        let mut c = BitSet::new();
+    #[test_with(u32, u64, usize)]
+    fn insert_100k<T: UnsignedInteger>() {
+        let mut c = GenericBitSet::<T>::new();
         for i in 0..100_000 {
             assert!(!c.add(i));
             assert!(c.add(i));
@@ -634,9 +679,10 @@ mod tests {
             assert!(c.contains(i));
         }
     }
-    #[test]
-    fn remove() {
-        let mut c = BitSet::new();
+
+    #[test_with(u32, u64, usize)]
+    fn remove<T: UnsignedInteger>() {
+        let mut c = GenericBitSet::<T>::new();
         for i in 0..1_000 {
             assert!(!c.add(i));
         }
@@ -649,9 +695,9 @@ mod tests {
         }
     }
 
-    #[test]
-    fn iter() {
-        let mut c = BitSet::new();
+    #[test_with(u32, u64, usize)]
+    fn iter<T: UnsignedInteger>() {
+        let mut c = GenericBitSet::<T>::new();
         for i in 0..100_000 {
             c.add(i);
         }
@@ -664,10 +710,10 @@ mod tests {
         assert_eq!(count, 100_000);
     }
 
-    #[test]
-    fn iter_odd_even() {
-        let mut odd = BitSet::new();
-        let mut even = BitSet::new();
+    #[test_with(u32, u64, usize)]
+    fn iter_odd_even<T: UnsignedInteger>() {
+        let mut odd = GenericBitSet::<T>::new();
+        let mut even = GenericBitSet::<T>::new();
         for i in 0..100_000 {
             if i % 2 == 1 {
                 odd.add(i);
@@ -681,11 +727,11 @@ mod tests {
         assert_eq!(BitSetAnd(&odd, &even).iter().count(), 0);
     }
 
-    #[test]
-    fn iter_random_add() {
+    #[test_with(u32, u64, usize)]
+    fn iter_random_add<T: UnsignedInteger>() {
         use rand::prelude::*;
 
-        let mut set = BitSet::new();
+        let mut set = GenericBitSet::<T>::new();
         let mut rng = thread_rng();
         let limit = 1_048_576;
         let mut added = 0;
@@ -698,13 +744,13 @@ mod tests {
         assert_eq!(set.iter().count(), added as usize);
     }
 
-    #[test]
-    fn iter_clusters() {
-        let mut set = BitSet::new();
+    #[test_with(u32, u64, usize)]
+    fn iter_clusters<T: UnsignedInteger>() {
+        let mut set = GenericBitSet::<T>::new();
         for x in 0..8 {
-            let x = (x * 3) << (::BITS * 2); // scale to the last slot
+            let x = (x * 3) << (T::LOG_BITS * 2); // scale to the last slot
             for y in 0..8 {
-                let y = (y * 3) << (::BITS);
+                let y = (y * 3) << (T::LOG_BITS);
                 for z in 0..8 {
                     let z = z * 2;
                     set.add(x + y + z);
@@ -714,9 +760,9 @@ mod tests {
         assert_eq!(set.iter().count(), 8usize.pow(3));
     }
 
-    #[test]
-    fn not() {
-        let mut c = BitSet::new();
+    #[test_with(u32, u64, usize)]
+    fn not<T: UnsignedInteger>() {
+        let mut c = GenericBitSet::<T>::new();
         for i in 0..10_000 {
             if i % 2 == 1 {
                 c.add(i);
@@ -731,31 +777,34 @@ mod tests {
 
 #[cfg(all(test, feature = "parallel"))]
 mod test_parallel {
-    use super::{BitSet, BitSetAnd, BitSetLike};
+    extern crate typed_test_gen;
+    use self::typed_test_gen::test_with;
+
+    use super::{BitSetAnd, BitSetLike, GenericBitSet, UnsignedInteger};
     use rayon::iter::ParallelIterator;
 
-    #[test]
-    fn par_iter_one() {
+    #[test_with(u32, u64, usize)]
+    fn par_iter_one<T: UnsignedInteger + Send + Sync>() {
         let step = 5000;
         let tests = 1_048_576 / step;
         for n in 0..tests {
             let n = n * step;
-            let mut set = BitSet::new();
+            let mut set = GenericBitSet::<T>::new();
             set.add(n);
             assert_eq!(set.par_iter().count(), 1);
         }
-        let mut set = BitSet::new();
+        let mut set = GenericBitSet::<T>::new();
         set.add(1_048_576 - 1);
         assert_eq!(set.par_iter().count(), 1);
     }
 
-    #[test]
-    fn par_iter_random_add() {
+    #[test_with(u32, u64, usize)]
+    fn par_iter_random_add<T: UnsignedInteger + Send + Sync>() {
         use rand::prelude::*;
         use std::collections::HashSet;
         use std::sync::{Arc, Mutex};
 
-        let mut set = BitSet::new();
+        let mut set = GenericBitSet::<T>::new();
         let mut check_set = HashSet::new();
         let mut rng = thread_rng();
         let limit = 1_048_576;
@@ -798,10 +847,10 @@ mod test_parallel {
         }
     }
 
-    #[test]
-    fn par_iter_odd_even() {
-        let mut odd = BitSet::new();
-        let mut even = BitSet::new();
+    #[test_with(u32, u64, usize)]
+    fn par_iter_odd_even<T: UnsignedInteger + Send + Sync>() {
+        let mut odd = GenericBitSet::<T>::new();
+        let mut even = GenericBitSet::<T>::new();
         for i in 0..100_000 {
             if i % 2 == 1 {
                 odd.add(i);
@@ -815,16 +864,16 @@ mod test_parallel {
         assert_eq!(BitSetAnd(&odd, &even).par_iter().count(), 0);
     }
 
-    #[test]
-    fn par_iter_clusters() {
+    #[test_with(u32, u64, usize)]
+    fn par_iter_clusters<T: UnsignedInteger + Send + Sync>() {
         use std::collections::HashSet;
         use std::sync::{Arc, Mutex};
-        let mut set = BitSet::new();
+        let mut set = GenericBitSet::<T>::new();
         let mut check_set = HashSet::new();
         for x in 0..8 {
-            let x = (x * 3) << (::BITS * 2); // scale to the last slot
+            let x = (x * 3) << (T::LOG_BITS * 2); // scale to the last slot
             for y in 0..8 {
-                let y = (y * 3) << (::BITS);
+                let y = (y * 3) << (T::LOG_BITS);
                 for z in 0..8 {
                     let z = z * 2;
                     let index = x + y + z;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,30 +1,33 @@
 use std::iter::{FromIterator, IntoIterator};
+use std::marker::PhantomData;
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not};
 use std::usize;
 
 use util::*;
 
-use {AtomicBitSet, BitIter, BitSet, BitSetLike, DrainableBitSet};
+use {AtomicBitSet, BitIter, BitSetLike, DrainableBitSet, GenericBitSet};
 
-impl<'a, B> BitOrAssign<&'a B> for BitSet
+impl<'a, B, T> BitOrAssign<&'a B> for GenericBitSet<T>
 where
-    B: BitSetLike,
+    T: UnsignedInteger,
+    B: BitSetLike<Underlying = T>,
 {
     fn bitor_assign(&mut self, lhs: &B) {
         use iter::State::Continue;
         let mut iter = lhs.iter();
         while let Some(level) = (1..LAYERS).find(|&level| iter.handle_level(level) == Continue) {
             let lower = level - 1;
-            let idx = iter.prefix[lower] as usize >> BITS;
+            let idx = iter.prefix[lower] as usize >> T::LOG_BITS;
             *self.layer_mut(lower, idx) |= lhs.get_from_layer(lower, idx);
         }
         self.layer3 |= lhs.layer3();
     }
 }
 
-impl<'a, B> BitAndAssign<&'a B> for BitSet
+impl<'a, B, T> BitAndAssign<&'a B> for GenericBitSet<T>
 where
-    B: BitSetLike,
+    T: UnsignedInteger,
+    B: BitSetLike<Underlying = T>,
 {
     fn bitand_assign(&mut self, lhs: &B) {
         use iter::State::*;
@@ -32,19 +35,19 @@ where
         iter.masks[LAYERS - 1] &= self.layer3();
         while let Some(level) = (1..LAYERS).find(|&level| iter.handle_level(level) == Continue) {
             let lower = level - 1;
-            let idx = iter.prefix[lower] as usize >> BITS;
+            let idx = iter.prefix[lower] as usize >> T::LOG_BITS;
             let our_layer = self.get_from_layer(lower, idx);
             let their_layer = lhs.get_from_layer(lower, idx);
 
             iter.masks[lower] &= our_layer;
 
-            let mut masks = [0; LAYERS];
+            let mut masks = [T::ZERO; LAYERS];
             masks[lower] = our_layer & !their_layer;
             BitIter::new(&mut *self, masks, iter.prefix).clear();
 
             *self.layer_mut(lower, idx) &= their_layer;
         }
-        let mut masks = [0; LAYERS];
+        let mut masks = [T::ZERO; LAYERS];
         masks[LAYERS - 1] = self.layer3() & !lhs.layer3();
         BitIter::new(&mut *self, masks, [0; LAYERS - 1]).clear();
 
@@ -52,35 +55,36 @@ where
     }
 }
 
-impl<'a, B> BitXorAssign<&'a B> for BitSet
+impl<'a, B, T> BitXorAssign<&'a B> for GenericBitSet<T>
 where
-    B: BitSetLike,
+    T: UnsignedInteger,
+    B: BitSetLike<Underlying = T>,
 {
     fn bitxor_assign(&mut self, lhs: &B) {
         use iter::State::*;
         let mut iter = lhs.iter();
         while let Some(level) = (1..LAYERS).find(|&level| iter.handle_level(level) == Continue) {
             let lower = level - 1;
-            let idx = iter.prefix[lower] as usize >> BITS;
+            let idx = iter.prefix[lower] as usize >> T::LOG_BITS;
 
             if lower == 0 {
                 *self.layer_mut(lower, idx) ^= lhs.get_from_layer(lower, idx);
 
                 let mut change_bit = |level| {
                     let lower = level - 1;
-                    let h = iter.prefix.get(level).cloned().unwrap_or(0) as usize;
-                    let l = iter.prefix[lower] as usize >> BITS;
-                    let mask = 1 << (l & !h);
+                    let h = iter.prefix.get(level).cloned().unwrap_or(0);
+                    let l = iter.prefix[lower] >> T::LOG_BITS;
+                    let mask = T::ONE << T::from_u32(l & !h);
 
-                    if self.get_from_layer(lower, l) == 0 {
-                        *self.layer_mut(level, h >> BITS) &= !mask;
+                    if self.get_from_layer(lower, l as usize) == T::ZERO {
+                        *self.layer_mut(level, h as usize >> T::LOG_BITS) &= !mask;
                     } else {
-                        *self.layer_mut(level, h >> BITS) |= mask;
+                        *self.layer_mut(level, h as usize >> T::LOG_BITS) |= mask;
                     }
                 };
 
                 change_bit(level);
-                if iter.masks[level] == 0 {
+                if iter.masks[level] == T::ZERO {
                     (2..LAYERS).for_each(change_bit);
                 }
             }
@@ -94,23 +98,32 @@ where
 ///
 /// [`BitSetLike`]: ../trait.BitSetLike.html
 #[derive(Debug, Clone)]
-pub struct BitSetAnd<A: BitSetLike, B: BitSetLike>(pub A, pub B);
+pub struct BitSetAnd<A, B>(pub A, pub B)
+where
+    A: BitSetLike,
+    B: BitSetLike<Underlying = A::Underlying>;
 
-impl<A: BitSetLike, B: BitSetLike> BitSetLike for BitSetAnd<A, B> {
+impl<A, B> BitSetLike for BitSetAnd<A, B>
+where
+    A: BitSetLike,
+    B: BitSetLike<Underlying = A::Underlying>,
+{
+    type Underlying = A::Underlying;
+
     #[inline]
-    fn layer3(&self) -> usize {
+    fn layer3(&self) -> Self::Underlying {
         self.0.layer3() & self.1.layer3()
     }
     #[inline]
-    fn layer2(&self, i: usize) -> usize {
+    fn layer2(&self, i: usize) -> Self::Underlying {
         self.0.layer2(i) & self.1.layer2(i)
     }
     #[inline]
-    fn layer1(&self, i: usize) -> usize {
+    fn layer1(&self, i: usize) -> Self::Underlying {
         self.0.layer1(i) & self.1.layer1(i)
     }
     #[inline]
-    fn layer0(&self, i: usize) -> usize {
+    fn layer0(&self, i: usize) -> Self::Underlying {
         self.0.layer0(i) & self.1.layer0(i)
     }
     #[inline]
@@ -119,7 +132,11 @@ impl<A: BitSetLike, B: BitSetLike> BitSetLike for BitSetAnd<A, B> {
     }
 }
 
-impl<A: DrainableBitSet, B: DrainableBitSet> DrainableBitSet for BitSetAnd<A, B> {
+impl<A, B> DrainableBitSet for BitSetAnd<A, B>
+where
+    A: DrainableBitSet,
+    B: DrainableBitSet<Underlying = A::Underlying>,
+{
     #[inline]
     fn remove(&mut self, i: Index) -> bool {
         if self.contains(i) {
@@ -138,23 +155,32 @@ impl<A: DrainableBitSet, B: DrainableBitSet> DrainableBitSet for BitSetAnd<A, B>
 ///
 /// [`BitSetLike`]: ../trait.BitSetLike.html
 #[derive(Debug, Clone)]
-pub struct BitSetOr<A: BitSetLike, B: BitSetLike>(pub A, pub B);
+pub struct BitSetOr<A, B>(pub A, pub B)
+where
+    A: BitSetLike,
+    B: BitSetLike<Underlying = A::Underlying>;
 
-impl<A: BitSetLike, B: BitSetLike> BitSetLike for BitSetOr<A, B> {
+impl<A, B> BitSetLike for BitSetOr<A, B>
+where
+    A: BitSetLike,
+    B: BitSetLike<Underlying = A::Underlying>,
+{
+    type Underlying = A::Underlying;
+
     #[inline]
-    fn layer3(&self) -> usize {
+    fn layer3(&self) -> Self::Underlying {
         self.0.layer3() | self.1.layer3()
     }
     #[inline]
-    fn layer2(&self, i: usize) -> usize {
+    fn layer2(&self, i: usize) -> Self::Underlying {
         self.0.layer2(i) | self.1.layer2(i)
     }
     #[inline]
-    fn layer1(&self, i: usize) -> usize {
+    fn layer1(&self, i: usize) -> Self::Underlying {
         self.0.layer1(i) | self.1.layer1(i)
     }
     #[inline]
-    fn layer0(&self, i: usize) -> usize {
+    fn layer0(&self, i: usize) -> Self::Underlying {
         self.0.layer0(i) | self.1.layer0(i)
     }
     #[inline]
@@ -163,7 +189,11 @@ impl<A: BitSetLike, B: BitSetLike> BitSetLike for BitSetOr<A, B> {
     }
 }
 
-impl<A: DrainableBitSet, B: DrainableBitSet> DrainableBitSet for BitSetOr<A, B> {
+impl<A, B> DrainableBitSet for BitSetOr<A, B>
+where
+    A: DrainableBitSet,
+    B: DrainableBitSet<Underlying = A::Underlying>,
+{
     #[inline]
     fn remove(&mut self, i: Index) -> bool {
         if self.contains(i) {
@@ -181,23 +211,30 @@ impl<A: DrainableBitSet, B: DrainableBitSet> DrainableBitSet for BitSetOr<A, B> 
 ///
 /// [`BitSetLike`]: ../trait.BitSetLike.html
 #[derive(Debug, Clone)]
-pub struct BitSetNot<A: BitSetLike>(pub A);
+pub struct BitSetNot<A>(pub A)
+where
+    A: BitSetLike;
 
-impl<A: BitSetLike> BitSetLike for BitSetNot<A> {
+impl<A> BitSetLike for BitSetNot<A>
+where
+    A: BitSetLike,
+{
+    type Underlying = A::Underlying;
+
     #[inline]
-    fn layer3(&self) -> usize {
-        !0
+    fn layer3(&self) -> A::Underlying {
+        !A::Underlying::ZERO
     }
     #[inline]
-    fn layer2(&self, _: usize) -> usize {
-        !0
+    fn layer2(&self, _: usize) -> A::Underlying {
+        !A::Underlying::ZERO
     }
     #[inline]
-    fn layer1(&self, _: usize) -> usize {
-        !0
+    fn layer1(&self, _: usize) -> A::Underlying {
+        !A::Underlying::ZERO
     }
     #[inline]
-    fn layer0(&self, i: usize) -> usize {
+    fn layer0(&self, i: usize) -> A::Underlying {
         !self.0.layer0(i)
     }
     #[inline]
@@ -212,11 +249,20 @@ impl<A: BitSetLike> BitSetLike for BitSetNot<A> {
 ///
 /// [`BitSetLike`]: ../trait.BitSetLike.html
 #[derive(Debug, Clone)]
-pub struct BitSetXor<A: BitSetLike, B: BitSetLike>(pub A, pub B);
+pub struct BitSetXor<A, B>(pub A, pub B)
+where
+    A: BitSetLike,
+    B: BitSetLike<Underlying = A::Underlying>;
 
-impl<A: BitSetLike, B: BitSetLike> BitSetLike for BitSetXor<A, B> {
+impl<A, B> BitSetLike for BitSetXor<A, B>
+where
+    A: BitSetLike,
+    B: BitSetLike<Underlying = A::Underlying>,
+{
+    type Underlying = A::Underlying;
+
     #[inline]
-    fn layer3(&self) -> usize {
+    fn layer3(&self) -> Self::Underlying {
         let xor = BitSetAnd(
             BitSetOr(&self.0, &self.1),
             BitSetNot(BitSetAnd(&self.0, &self.1)),
@@ -224,7 +270,7 @@ impl<A: BitSetLike, B: BitSetLike> BitSetLike for BitSetXor<A, B> {
         xor.layer3()
     }
     #[inline]
-    fn layer2(&self, id: usize) -> usize {
+    fn layer2(&self, id: usize) -> Self::Underlying {
         let xor = BitSetAnd(
             BitSetOr(&self.0, &self.1),
             BitSetNot(BitSetAnd(&self.0, &self.1)),
@@ -232,7 +278,7 @@ impl<A: BitSetLike, B: BitSetLike> BitSetLike for BitSetXor<A, B> {
         xor.layer2(id)
     }
     #[inline]
-    fn layer1(&self, id: usize) -> usize {
+    fn layer1(&self, id: usize) -> Self::Underlying {
         let xor = BitSetAnd(
             BitSetOr(&self.0, &self.1),
             BitSetNot(BitSetAnd(&self.0, &self.1)),
@@ -240,7 +286,7 @@ impl<A: BitSetLike, B: BitSetLike> BitSetLike for BitSetXor<A, B> {
         xor.layer1(id)
     }
     #[inline]
-    fn layer0(&self, id: usize) -> usize {
+    fn layer0(&self, id: usize) -> Self::Underlying {
         let xor = BitSetAnd(
             BitSetOr(&self.0, &self.1),
             BitSetNot(BitSetAnd(&self.0, &self.1)),
@@ -260,23 +306,27 @@ impl<A: BitSetLike, B: BitSetLike> BitSetLike for BitSetXor<A, B> {
 /// `BitSetAll` is a bitset with all bits set. Essentially the same as
 /// `BitSetNot(BitSet::new())` but without any allocation.
 #[derive(Debug, Clone)]
-pub struct BitSetAll;
-impl BitSetLike for BitSetAll {
+pub struct BitSetAll<T: UnsignedInteger> {
+    _phantom: PhantomData<T>,
+}
+impl<T: UnsignedInteger> BitSetLike for BitSetAll<T> {
+    type Underlying = T;
+
     #[inline]
-    fn layer3(&self) -> usize {
-        usize::MAX
+    fn layer3(&self) -> Self::Underlying {
+        T::MAX
     }
     #[inline]
-    fn layer2(&self, _id: usize) -> usize {
-        usize::MAX
+    fn layer2(&self, _id: usize) -> Self::Underlying {
+        T::MAX
     }
     #[inline]
-    fn layer1(&self, _id: usize) -> usize {
-        usize::MAX
+    fn layer1(&self, _id: usize) -> Self::Underlying {
+        T::MAX
     }
     #[inline]
-    fn layer0(&self, _id: usize) -> usize {
-        usize::MAX
+    fn layer0(&self, _id: usize) -> Self::Underlying {
+        T::MAX
     }
     #[inline]
     fn contains(&self, _i: Index) -> bool {
@@ -286,8 +336,10 @@ impl BitSetLike for BitSetAll {
 
 macro_rules! operator {
     ( impl < ( $( $lifetime:tt )* ) ( $( $arg:ident ),* ) > for $bitset:ty ) => {
-        impl<$( $lifetime, )* $( $arg ),*> IntoIterator for $bitset
-            where $( $arg: BitSetLike ),*
+        impl<$( $lifetime, )* T, $( $arg ),*> IntoIterator for $bitset
+            where
+                T: UnsignedInteger,
+                $( $arg: BitSetLike<Underlying = T> ),*
         {
             type Item = <BitIter<Self> as Iterator>::Item;
             type IntoIter = BitIter<Self>;
@@ -296,8 +348,10 @@ macro_rules! operator {
             }
         }
 
-        impl<$( $lifetime, )* $( $arg ),*> Not for $bitset
-            where $( $arg: BitSetLike ),*
+        impl<$( $lifetime, )* T, $( $arg ),*> Not for $bitset
+            where
+                T: UnsignedInteger,
+                $( $arg: BitSetLike<Underlying = T> ),*
         {
             type Output = BitSetNot<Self>;
             fn not(self) -> Self::Output {
@@ -305,32 +359,38 @@ macro_rules! operator {
             }
         }
 
-        impl<$( $lifetime, )* $( $arg, )* T> BitAnd<T> for $bitset
-            where T: BitSetLike,
-                  $( $arg: BitSetLike ),*
+        impl<$( $lifetime, )* T, $( $arg, )* OtherBitSetLike> BitAnd<OtherBitSetLike> for $bitset
+            where
+                T: UnsignedInteger,
+                OtherBitSetLike: BitSetLike<Underlying = T>,
+                $( $arg: BitSetLike<Underlying = T> ),*
         {
-            type Output = BitSetAnd<Self, T>;
-            fn bitand(self, rhs: T) -> Self::Output {
+            type Output = BitSetAnd<Self, OtherBitSetLike>;
+            fn bitand(self, rhs: OtherBitSetLike) -> Self::Output {
                 BitSetAnd(self, rhs)
             }
         }
 
-        impl<$( $lifetime, )* $( $arg, )* T> BitOr<T> for $bitset
-            where T: BitSetLike,
-                  $( $arg: BitSetLike ),*
+        impl<$( $lifetime, )* T, $( $arg, )* OtherBitSetLike> BitOr<OtherBitSetLike> for $bitset
+            where
+                T: UnsignedInteger,
+                OtherBitSetLike: BitSetLike<Underlying = T>,
+                $( $arg: BitSetLike<Underlying = T> ),*
         {
-            type Output = BitSetOr<Self, T>;
-            fn bitor(self, rhs: T) -> Self::Output {
+            type Output = BitSetOr<Self, OtherBitSetLike>;
+            fn bitor(self, rhs: OtherBitSetLike) -> Self::Output {
                 BitSetOr(self, rhs)
             }
         }
 
-        impl<$( $lifetime, )* $( $arg, )* T> BitXor<T> for $bitset
-            where T: BitSetLike,
-                  $( $arg: BitSetLike ),*
+        impl<$( $lifetime, )* T, $( $arg, )* OtherBitSetLike> BitXor<OtherBitSetLike> for $bitset
+            where
+                T: UnsignedInteger,
+                OtherBitSetLike: BitSetLike<Underlying = T>,
+                $( $arg: BitSetLike<Underlying = T> ),*
         {
-            type Output = BitSetXor<Self, T>;
-            fn bitxor(self, rhs: T) -> Self::Output {
+            type Output = BitSetXor<Self, OtherBitSetLike>;
+            fn bitxor(self, rhs: OtherBitSetLike) -> Self::Output {
                 BitSetXor(self, rhs)
             }
         }
@@ -338,10 +398,8 @@ macro_rules! operator {
     }
 }
 
-operator!(impl<()()> for BitSet);
-operator!(impl<('a)()> for &'a BitSet);
-operator!(impl<()()> for AtomicBitSet);
-operator!(impl<('a)()> for &'a AtomicBitSet);
+operator!(impl<()()> for GenericBitSet<T>);
+operator!(impl<('a)()> for &'a GenericBitSet<T>);
 operator!(impl<()(A)> for BitSetNot<A>);
 operator!(impl<('a)(A)> for &'a BitSetNot<A>);
 operator!(impl<()(A, B)> for BitSetAnd<A, B>);
@@ -350,80 +408,203 @@ operator!(impl<()(A, B)> for BitSetOr<A, B>);
 operator!(impl<('a)(A, B)> for &'a BitSetOr<A, B>);
 operator!(impl<()(A, B)> for BitSetXor<A, B>);
 operator!(impl<('a)(A, B)> for &'a BitSetXor<A, B>);
-operator!(impl<()()> for BitSetAll);
-operator!(impl<('a)()> for &'a BitSetAll);
+operator!(impl<()()> for BitSetAll<T>);
+operator!(impl<('a)()> for &'a BitSetAll<T>);
 
-macro_rules! iterator {
-    ( $bitset:ident ) => {
-        impl FromIterator<Index> for $bitset {
-            fn from_iter<T>(iter: T) -> Self
-            where
-                T: IntoIterator<Item = Index>,
-            {
-                let mut bitset = $bitset::new();
-                for item in iter {
-                    bitset.add(item);
-                }
-                bitset
-            }
+impl<T: UnsignedInteger> FromIterator<Index> for GenericBitSet<T> {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = Index>,
+    {
+        let mut bitset = Self::new();
+        for item in iter {
+            bitset.add(item);
         }
-
-        impl<'a> FromIterator<&'a Index> for $bitset {
-            fn from_iter<T>(iter: T) -> Self
-            where
-                T: IntoIterator<Item = &'a Index>,
-            {
-                let mut bitset = $bitset::new();
-                for item in iter {
-                    bitset.add(*item);
-                }
-                bitset
-            }
-        }
-
-        impl Extend<Index> for $bitset {
-            fn extend<T>(&mut self, iter: T)
-            where
-                T: IntoIterator<Item = Index>,
-            {
-                for item in iter {
-                    self.add(item);
-                }
-            }
-        }
-
-        impl<'a> Extend<&'a Index> for $bitset {
-            fn extend<T>(&mut self, iter: T)
-            where
-                T: IntoIterator<Item = &'a Index>,
-            {
-                for item in iter {
-                    self.add(*item);
-                }
-            }
-        }
-    };
+        bitset
+    }
 }
 
-iterator!(BitSet);
-iterator!(AtomicBitSet);
+impl<'a, T: UnsignedInteger> FromIterator<&'a Index> for GenericBitSet<T> {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = &'a Index>,
+    {
+        let mut bitset = Self::new();
+        for item in iter {
+            bitset.add(*item);
+        }
+        bitset
+    }
+}
+
+impl<T: UnsignedInteger> Extend<Index> for GenericBitSet<T> {
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = Index>,
+    {
+        for item in iter {
+            self.add(item);
+        }
+    }
+}
+
+impl<'a, T: UnsignedInteger> Extend<&'a Index> for GenericBitSet<T> {
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = &'a Index>,
+    {
+        for item in iter {
+            self.add(*item);
+        }
+    }
+}
+
+// All specialized implementations for `AtomicBitSet`
+
+impl FromIterator<Index> for AtomicBitSet {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = Index>,
+    {
+        let mut bitset = AtomicBitSet::new();
+        for item in iter {
+            bitset.add(item);
+        }
+        bitset
+    }
+}
+impl<'a> FromIterator<&'a Index> for AtomicBitSet {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = &'a Index>,
+    {
+        let mut bitset = AtomicBitSet::new();
+        for item in iter {
+            bitset.add(*item);
+        }
+        bitset
+    }
+}
+impl Extend<Index> for AtomicBitSet {
+    fn extend<T>(&mut self, iter: T)
+    where
+        T: IntoIterator<Item = Index>,
+    {
+        for item in iter {
+            self.add(item);
+        }
+    }
+}
+impl<'a> Extend<&'a Index> for AtomicBitSet {
+    fn extend<T>(&mut self, iter: T)
+    where
+        T: IntoIterator<Item = &'a Index>,
+    {
+        for item in iter {
+            self.add(*item);
+        }
+    }
+}
+impl IntoIterator for AtomicBitSet {
+    type Item = <BitIter<Self> as Iterator>::Item;
+    type IntoIter = BitIter<Self>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+impl<'a> IntoIterator for &'a AtomicBitSet {
+    type Item = <BitIter<Self> as Iterator>::Item;
+    type IntoIter = BitIter<Self>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+impl Not for AtomicBitSet {
+    type Output = BitSetNot<Self>;
+    fn not(self) -> Self::Output {
+        BitSetNot(self)
+    }
+}
+impl<'a> Not for &'a AtomicBitSet {
+    type Output = BitSetNot<Self>;
+    fn not(self) -> Self::Output {
+        BitSetNot(self)
+    }
+}
+impl<OtherBitSetLike> BitAnd<OtherBitSetLike> for AtomicBitSet
+where
+    OtherBitSetLike: BitSetLike<Underlying = usize>,
+{
+    type Output = BitSetAnd<Self, OtherBitSetLike>;
+    fn bitand(self, rhs: OtherBitSetLike) -> Self::Output {
+        BitSetAnd(self, rhs)
+    }
+}
+impl<'a, OtherBitSetLike> BitAnd<OtherBitSetLike> for &'a AtomicBitSet
+where
+    OtherBitSetLike: BitSetLike<Underlying = usize>,
+{
+    type Output = BitSetAnd<Self, OtherBitSetLike>;
+    fn bitand(self, rhs: OtherBitSetLike) -> Self::Output {
+        BitSetAnd(self, rhs)
+    }
+}
+impl<OtherBitSetLike> BitOr<OtherBitSetLike> for AtomicBitSet
+where
+    OtherBitSetLike: BitSetLike<Underlying = usize>,
+{
+    type Output = BitSetOr<Self, OtherBitSetLike>;
+    fn bitor(self, rhs: OtherBitSetLike) -> Self::Output {
+        BitSetOr(self, rhs)
+    }
+}
+impl<'a, OtherBitSetLike> BitOr<OtherBitSetLike> for &'a AtomicBitSet
+where
+    OtherBitSetLike: BitSetLike<Underlying = usize>,
+{
+    type Output = BitSetOr<Self, OtherBitSetLike>;
+    fn bitor(self, rhs: OtherBitSetLike) -> Self::Output {
+        BitSetOr(self, rhs)
+    }
+}
+impl<OtherBitSetLike> BitXor<OtherBitSetLike> for AtomicBitSet
+where
+    OtherBitSetLike: BitSetLike<Underlying = usize>,
+{
+    type Output = BitSetXor<Self, OtherBitSetLike>;
+    fn bitxor(self, rhs: OtherBitSetLike) -> Self::Output {
+        BitSetXor(self, rhs)
+    }
+}
+impl<'a, OtherBitSetLike> BitXor<OtherBitSetLike> for &'a AtomicBitSet
+where
+    OtherBitSetLike: BitSetLike<Underlying = usize>,
+{
+    type Output = BitSetXor<Self, OtherBitSetLike>;
+    fn bitxor(self, rhs: OtherBitSetLike) -> Self::Output {
+        BitSetXor(self, rhs)
+    }
+}
 
 #[cfg(test)]
 mod tests {
-    use {BitSet, BitSetLike, BitSetXor, Index};
+    extern crate typed_test_gen;
+    use self::typed_test_gen::test_with;
 
-    #[test]
-    fn or_assign() {
+    use {BitSetLike, BitSetXor, GenericBitSet, Index, UnsignedInteger};
+
+    #[test_with(u32, u64, usize)]
+    fn or_assign<T: UnsignedInteger>() {
         use std::collections::HashSet;
         use std::mem::size_of;
 
-        let usize_bits = size_of::<usize>() as u32 * 8;
+        let uint_bits = size_of::<T>() as u32 * 8;
         let n = 10_000;
-        let f1 = &|n| 7 * usize_bits * n;
-        let f2 = &|n| 13 * usize_bits * n;
+        let f1 = &|i| (7 * uint_bits * i) % T::MAX_EID;
+        let f2 = &|i| (13 * uint_bits * i) % T::MAX_EID;
 
-        let mut c1: BitSet = (0..n).map(f1).collect();
-        let c2: BitSet = (0..n).map(f2).collect();
+        let mut c1: GenericBitSet<T> = (0..n).map(f1).collect();
+        let c2: GenericBitSet<T> = (0..n).map(f2).collect();
 
         c1 |= &c2;
 
@@ -432,15 +613,15 @@ mod tests {
         assert_eq!(c1.iter().collect::<HashSet<_>>(), &h1 | &h2);
     }
 
-    #[test]
-    fn or_assign_random() {
+    #[test_with(u32, u64, usize)]
+    fn or_assign_random<T: UnsignedInteger>() {
         use rand::prelude::*;
 
         use std::collections::HashSet;
         let limit = 1_048_576;
         let mut rng = thread_rng();
 
-        let mut set1 = BitSet::new();
+        let mut set1 = GenericBitSet::<T>::new();
         let mut check_set1 = HashSet::new();
         for _ in 0..(limit / 100) {
             let index = rng.gen_range(0, limit);
@@ -448,7 +629,7 @@ mod tests {
             check_set1.insert(index);
         }
 
-        let mut set2 = BitSet::new();
+        let mut set2 = GenericBitSet::<T>::new();
         let mut check_set2 = HashSet::new();
         for _ in 0..(limit / 100) {
             let index = rng.gen_range(0, limit);
@@ -471,18 +652,18 @@ mod tests {
         assert_eq!(hs, set1.iter().collect());
     }
 
-    #[test]
-    fn and_assign() {
+    #[test_with(u32, u64, usize)]
+    fn and_assign<T: UnsignedInteger>() {
         use std::collections::HashSet;
         use std::mem::size_of;
 
-        let usize_bits = size_of::<usize>() as u32 * 8;
+        let uint_bits = size_of::<T>() as u32 * 8;
         let n = 10_000;
-        let f1 = &|n| 7 * usize_bits * n;
-        let f2 = &|n| 13 * usize_bits * n;
+        let f1 = &|n| (7 * uint_bits * n) % T::MAX_EID;
+        let f2 = &|n| (13 * uint_bits * n) % T::MAX_EID;
 
-        let mut c1: BitSet = (0..n).map(f1).collect();
-        let c2: BitSet = (0..n).map(f2).collect();
+        let mut c1: GenericBitSet<T> = (0..n).map(f1).collect();
+        let c2: GenericBitSet<T> = (0..n).map(f2).collect();
 
         c1 &= &c2;
 
@@ -491,53 +672,49 @@ mod tests {
         assert_eq!(c1.iter().collect::<HashSet<_>>(), &h1 & &h2);
     }
 
-    #[test]
-    fn and_assign_specific() {
-        use util::BITS;
-
-        let mut c1 = BitSet::new();
+    #[test_with(u32, u64, usize)]
+    fn and_assign_specific<T: UnsignedInteger>() {
+        let mut c1 = GenericBitSet::<T>::new();
         c1.add(0);
-        let common = ((1 << BITS) << BITS) << BITS;
+        let common = ((1 << T::LOG_BITS) << T::LOG_BITS) << T::LOG_BITS;
         c1.add(common);
-        c1.add((((1 << BITS) << BITS) + 1) << BITS);
+        c1.add((((1 << T::LOG_BITS) << T::LOG_BITS) + 1) << T::LOG_BITS);
 
-        let mut c2: BitSet = BitSet::new();
+        let mut c2 = GenericBitSet::<T>::new();
         c2.add(common);
-        c2.add((((1 << BITS) << BITS) + 2) << BITS);
+        c2.add((((1 << T::LOG_BITS) << T::LOG_BITS) + 2) << T::LOG_BITS);
 
         c1 &= &c2;
 
         assert_eq!(c1.iter().collect::<Vec<_>>(), [common]);
     }
 
-    #[test]
-    fn and_assign_with_modification() {
-        use util::BITS;
-
-        let mut c1 = BitSet::new();
+    #[test_with(u32, u64, usize)]
+    fn and_assign_with_modification<T: UnsignedInteger>() {
+        let mut c1 = GenericBitSet::<T>::new();
         c1.add(0);
-        c1.add((1 << BITS) << BITS);
+        c1.add((1 << T::LOG_BITS) << T::LOG_BITS);
 
-        let mut c2: BitSet = BitSet::new();
+        let mut c2 = GenericBitSet::<T>::new();
         c2.add(0);
 
         c1 &= &c2;
 
-        let added = ((1 << BITS) + 1) << BITS;
+        let added = ((1 << T::LOG_BITS) + 1) << T::LOG_BITS;
         c1.add(added);
 
         assert_eq!(c1.iter().collect::<Vec<_>>(), [0, added]);
     }
 
-    #[test]
-    fn and_assign_random() {
+    #[test_with(u32, u64, usize)]
+    fn and_assign_random<T: UnsignedInteger>() {
         use rand::prelude::*;
 
         use std::collections::HashSet;
         let limit = 1_048_576;
         let mut rng = thread_rng();
 
-        let mut set1 = BitSet::new();
+        let mut set1 = GenericBitSet::<T>::new();
         let mut check_set1 = HashSet::new();
         for _ in 0..(limit / 100) {
             let index = rng.gen_range(0, limit);
@@ -545,7 +722,7 @@ mod tests {
             check_set1.insert(index);
         }
 
-        let mut set2 = BitSet::new();
+        let mut set2 = GenericBitSet::<T>::new();
         let mut check_set2 = HashSet::new();
         for _ in 0..(limit / 100) {
             let index = rng.gen_range(0, limit);
@@ -568,18 +745,18 @@ mod tests {
         assert_eq!(hs, set1.iter().collect());
     }
 
-    #[test]
-    fn xor_assign() {
+    #[test_with(u32, u64, usize)]
+    fn xor_assign<T: UnsignedInteger>() {
         use std::collections::HashSet;
         use std::mem::size_of;
 
-        let usize_bits = size_of::<usize>() as u32 * 8;
+        let uint_bits = size_of::<T>() as u32 * 8;
         let n = 10_000;
-        let f1 = &|n| 7 * usize_bits * n;
-        let f2 = &|n| 13 * usize_bits * n;
+        let f1 = &|n| (7 * uint_bits * n) % T::MAX_EID;
+        let f2 = &|n| (13 * uint_bits * n) % T::MAX_EID;
 
-        let mut c1: BitSet = (0..n).map(f1).collect();
-        let c2: BitSet = (0..n).map(f2).collect();
+        let mut c1: GenericBitSet<T> = (0..n).map(f1).collect();
+        let c2: GenericBitSet<T> = (0..n).map(f2).collect();
         c1 ^= &c2;
 
         let h1: HashSet<_> = (0..n).map(f1).collect();
@@ -587,20 +764,18 @@ mod tests {
         assert_eq!(c1.iter().collect::<HashSet<_>>(), &h1 ^ &h2);
     }
 
-    #[test]
-    fn xor_assign_specific() {
-        use util::BITS;
-
-        let mut c1 = BitSet::new();
+    #[test_with(u32, u64, usize)]
+    fn xor_assign_specific<T: UnsignedInteger>() {
+        let mut c1 = GenericBitSet::<T>::new();
         c1.add(0);
-        let common = ((1 << BITS) << BITS) << BITS;
+        let common = ((1 << T::LOG_BITS) << T::LOG_BITS) << T::LOG_BITS;
         c1.add(common);
-        let a = (((1 << BITS) + 1) << BITS) << BITS;
+        let a = (((1 << T::LOG_BITS) + 1) << T::LOG_BITS) << T::LOG_BITS;
         c1.add(a);
 
-        let mut c2: BitSet = BitSet::new();
+        let mut c2 = GenericBitSet::<T>::new();
         c2.add(common);
-        let b = (((1 << BITS) + 2) << BITS) << BITS;
+        let b = (((1 << T::LOG_BITS) + 2) << T::LOG_BITS) << T::LOG_BITS;
         c2.add(b);
 
         c1 ^= &c2;
@@ -608,14 +783,14 @@ mod tests {
         assert_eq!(c1.iter().collect::<Vec<_>>(), [0, a, b]);
     }
 
-    #[test]
-    fn xor_assign_random() {
+    #[test_with(u32, u64, usize)]
+    fn xor_assign_random<T: UnsignedInteger>() {
         use rand::prelude::*;
         use std::collections::HashSet;
         let limit = 1_048_576;
         let mut rng = thread_rng();
 
-        let mut set1 = BitSet::new();
+        let mut set1 = GenericBitSet::<T>::new();
         let mut check_set1 = HashSet::new();
         for _ in 0..(limit / 100) {
             let index = rng.gen_range(0, limit);
@@ -623,7 +798,7 @@ mod tests {
             check_set1.insert(index);
         }
 
-        let mut set2 = BitSet::new();
+        let mut set2 = GenericBitSet::<T>::new();
         let mut check_set2 = HashSet::new();
         for _ in 0..(limit / 100) {
             let index = rng.gen_range(0, limit);
@@ -646,9 +821,9 @@ mod tests {
         assert_eq!(hs, set1.iter().collect());
     }
 
-    #[test]
-    fn operators() {
-        let mut bitset = BitSet::new();
+    #[test_with(u32, u64, usize)]
+    fn operators<T: UnsignedInteger>() {
+        let mut bitset = GenericBitSet::<T>::new();
         bitset.add(1);
         bitset.add(3);
         bitset.add(5);
@@ -656,7 +831,7 @@ mod tests {
         bitset.add(200);
         bitset.add(50001);
 
-        let mut other = BitSet::new();
+        let mut other = GenericBitSet::<T>::new();
         other.add(1);
         other.add(3);
         other.add(50000);
@@ -695,16 +870,16 @@ mod tests {
         }
     }
 
-    #[test]
-    fn xor() {
+    #[test_with(u32, u64, usize)]
+    fn xor<T: UnsignedInteger>() {
         // 0011
-        let mut bitset = BitSet::new();
+        let mut bitset = GenericBitSet::<T>::new();
         bitset.add(2);
         bitset.add(3);
         bitset.add(50000);
 
         // 0101
-        let mut other = BitSet::new();
+        let mut other = GenericBitSet::<T>::new();
         other.add(1);
         other.add(3);
         other.add(50000);


### PR DESCRIPTION
This PR makes the whole crate work with `u32`, `u64`, and `usize` underlying data for representing bits, through a trait that could be used for a user wanting to generate a `BitSet` with other integer types. All unit tests are run on all versions. All operations, features and iterators are compatible, except `AtomicBitSet`, which is still only hardcoded for `usize`.

Operations are for now strictly between `GenericBitSet` with the same underlying representation, but this might be generalized in the future, providing ops between any pair of sets. I've not looked into this.

For backward compatibility, I've left the name `BitSet` specialized with `usize`, adding a new name `GenericBitSet<T>` for other specializations.

### My use case
I'm using `specs` and `hibitset` for a project that is compiled to WASM, which for now has a 32 bit address size, meaning `usize` has 32 bits size, and I can only work with up to a million-ish entities. In the long term I will wish for more than that number, and wasm supports some `u64` operations, so I would wager the performance hit is not gonna be too bad if I build a `BitSet` from a `u64`, but I'll raise the maximum to 16 million-ish entities.

### Other use cases
The performance of the `BitSet` hierarchy will depend a lot on the density of the bits: when density is more than 1/64, the hierarchy almost becomes overhead. Being able to choose the layers' densities might be nice.

### Limitations:
 - Code is harder to read
 - I know there's another PR about generalizing the number of layers. I've not looked into compatibility/merging the two, this might be a hassle. Plus the two together might make the code even more hard to read.